### PR TITLE
Previous Distributions Selection

### DIFF
--- a/site/src/site/pages/download.groovy
+++ b/site/src/site/pages/download.groovy
@@ -57,7 +57,8 @@ layout 'layouts/main.groovy', true,
                                 h1 'Distributions'
                                 p 'You can download a binary or a documentation bundle.'
 
-                                distributions.each { dist ->
+
+                                distributions.pop().each { dist ->
                                     h2 {
                                         i(class: 'fa grails-icon') {
                                             img src:"img/grails-cupsonly-logo-black.svg"
@@ -104,6 +105,21 @@ layout 'layouts/main.groovy', true,
                                             a(href: pkg.releaseNotes, ' release notes')
                                             yield ' for more information.'
                                         }
+                                    }
+                                }
+                            }
+                            
+                            a(name: 'versions') {}
+                            article{
+                                h2 'Previous Versions'
+                                p 'You can browse the downloads of previous versions of Grails since Grails 1.2.0:'
+                                        
+                                distributions = distributions.reverse()
+
+                                select(class: 'form-control', onchange: "window.location.href='https://github.com/grails/grails-core/releases/download/v'+ this.value +'/grails-' + this.value + '.zip'") {
+                                    option 'Select a version'
+                                    distributions.each{ dist ->
+                                       option "${dist.packages.first().version}"
                                     }
                                 }
                             }

--- a/site/src/site/sitemap.groovy
+++ b/site/src/site/sitemap.groovy
@@ -82,6 +82,24 @@ downloads {
     //         releaseNotes 'http://jira.codehaus.org/secure/ReleaseNote.jspa?projectId=10242&version=20612'
     //     }
     // }
+
+    def previousVersions = [
+        '1.2.0', '1.2.1', '1.2.2', '1.2.3', '1.2.4', '1.2.5',
+        '1.3.0', '1.3.1', '1.3.2', '1.3.3', '1.3.4', '1.3.5', '1.3.6', '1.3.7', '1.3.8', '1.3.9',
+        '2.0.0', '2.0.1', '2.0.2', '2.0.3', '2.0.4',
+        '2.1.0', '2.1.1', '2.1.2', '2.1.3', '2.1.4', '2.1.5',
+        '2.2.0', '2.2.1', '2.2.2', '2.2.3', '2.2.4', '2.2.5',
+        '2.3.0', '2.3.1', '2.3.2', '2.3.3', '2.3.4', '2.3.5', '2.3.6', '2.3.7', '2.3.8', '2.3.9', '2.3.10', '2.3.11',
+        '2.4.0', '2.4.1', '2.4.2', '2.4.3'
+    ]
+    previousVersions.each{ versionNumber ->
+        distribution("${versionNumber}"){
+            version("${versionNumber}"){
+                releaseNotes "https://github.com/grails/grails-core/releases/tag/v${versionNumber}"
+            }
+        }
+    }
+    //placing last to use pop on the download page
     def currentStableVersion = '2.4.4'
     distribution("Grails $currentStableVersion") {
         description {


### PR DESCRIPTION
Created a previous distributions selection menu that connects users to previous versions of grails

- download.groovy
-- used pop() to get and remove last element (most recent) distribution in the distribution list
-- reversed distribution list to show latest (most recent) to earliest
- sitemap.groovy
-- updated to have full list of distribution versions in order from earliest to latest