### PR TITLE
Fixed broken link to missing groovy-weekly.html

### DIFF
--- a/site/src/site/pages/community.groovy
+++ b/site/src/site/pages/community.groovy
@@ -37,7 +37,7 @@ layout 'layouts/main.groovy', true,
                                 '''
                                 ul {
                                     li {
-                                        a(href: 'groovy-weekly.html', 'Groovy Weekly Newsletter')
+                                        a(href: 'http://www.groovy-lang.org/groovy-weekly.html', 'Groovy Weekly Newsletter')
                                         yieldUnescaped ' &mdash; links to articles, presentations, tweets, podcasts, every Tuesday'
                                     }
                                     li {


### PR DESCRIPTION
Fixed broken link from local groovy-weekly.html to external http://www.groovy-lang.org/groovy-weekly.html. Not sure if this is the desired outcome, or is there's just a missing local file, but at least it's not a broken link. Btw, this missing page didn't show up in the broken link report after generation.

I tested the new link in the generated site and it goes to the proper external page.