### PR TITLE
Adding 3.0.x and 2.5.x branches to Travis build status

### DIFF
--- a/site/src/site/pages/buildstatus.groovy
+++ b/site/src/site/pages/buildstatus.groovy
@@ -50,6 +50,8 @@ layout 'layouts/main.groovy', true,
                                     }
                                 }
                                 renderBuilds(['Grails Master': ['grails/grails-core','master'],
+                                        'Grails 3.0.x Branch': ['grails/grails-core', '3.0.x'],
+                                        'Grails 2.5.x Branch': ['grails/grails-core', '2.5.x'],
                                         'Grails 2.4.x Branch': ['grails/grails-core', '2.4.x'],
                                         'Grails 2.3.x Branch': ['grails/grails-core', '2.3.x']
                                         ])


### PR DESCRIPTION
Since last edit of this page, obviously Grails 2.5 and 3.0 series have been released. Since edits also land on these branches, it makes sense to display build status.