### PR TITLE
Fixed search field style. It was looking ugly.

### DIFF
--- a/site/src/site/pages/search.groovy
+++ b/site/src/site/pages/search.groovy
@@ -31,7 +31,7 @@ layout 'layouts/main.groovy', true,
                                 'gcse:search'(linkTarget: '_blank'){}
                                 style '''
                                     .gsc-input-box {
-                                        height: 30px;
+                                        height: 32px;
                                     }
                                     input.gsc-search-button, input.gsc-search-button-v2 {
                                         height: 30px;


### PR DESCRIPTION
Search page at https://grails.org/search.html is using Google Custom Search, but is looking ugly right now. I've added a small css fix just increasing the height of wrapping div to 2px. 