### PR TITLE
fixing a circular link that should go to the github issues page.

### DIFF
--- a/site/src/site/pages/contribute.groovy
+++ b/site/src/site/pages/contribute.groovy
@@ -67,7 +67,7 @@ layout 'layouts/main.groovy', true,
                                 h2 'Reporting issues'
                                 p {
                                     yield 'The Grails project uses '
-                                    a(href: 'contribute.html#reporting-issues', 'Github issues')
+                                    a(href: 'https://github.com/grails/grails-core/issues', 'Github issues')
                                     yield '''
                                         to report and track issues, feature enhancements, and new features.
                                         Be sure to be signed-up and logged-in, as explained below, before proceeding.


### PR DESCRIPTION
the link was pointing to itself. this seemed a more useful target. 