### PR TITLE
rendering of single-page-documentation fixed

### DIFF
--- a/site/src/site/assets/css/hide-overflow.css
+++ b/site/src/site/assets/css/hide-overflow.css
@@ -1,0 +1,3 @@
+.st-content-inner {
+	overflow: hidden !important;
+}

--- a/site/src/site/layouts/iframedoc.groovy
+++ b/site/src/site/layouts/iframedoc.groovy
@@ -8,9 +8,10 @@
  * @param iframeTarget , the URL of the page to be included as an iframe
  */
 layout 'layouts/page.groovy', true,
+		extraStyles: ['hide-overflow.css'],
         mainContent: contents {
             div {
                 include template: 'includes/topmenu.groovy'
             }
-            iframe(class: 'doc-embed', frameborder: '0', height: '100%', width: '100%', src: iframeTarget) {}
+            iframe(class: 'doc-embed', frameborder: '0', height: '100%', width: '100%', style:'display: block;padding-bottom: 70px;', src: iframeTarget) {}
         }


### PR DESCRIPTION
Hi! The page under `https://grails.org/single-page-documentation.html` (first google hit for 'grails docs') has two vertical sliders in it (at least in chrome and FF). Here's a PR that has chosen one approach to fix it.

I have added one extra css file which is then referenced from `iframedoc.groovy`. This css makes one of the scrollbars to go away. Then, there is another trouble - the iframe body overflows out of the screen by 70px (navbar height). I added the padding so that it becomes fully visible again. It's not perfect, but...

The issue with this is that navbar height changes (grows) as you make browser window smaller, until it changes to 'mobile view'. That could be fixed later. 
*edit: clicking links within the iframe also doesn't refresh the url displayed in the address bar, which isn't nice, either.

Alternative would be simply to make a redirect from `https://grails.org/single-page-documentation.html` to `http://grails.github.io/grails-doc/latest/`. Let me know if like that idea better and I can make another PR. :)