### PR TITLE
embbed single page doc via http instead of https. Closes #39

### DIFF
--- a/site/src/site/sitemap.groovy
+++ b/site/src/site/sitemap.groovy
@@ -50,7 +50,7 @@ pages {
     page 'events', 'events', [category: 'Community', allEvents: allEvents]
     page 'api', 'api', [category: 'Documentation', iframeTarget: 'https://docs.grails.org/latest/api/']
     page 'plugins', 'plugins', [category: 'Documentation', iframeTarget: 'https://sheehan.github.io/grails3-plugins/']
-    page 'singlepagedocumentation', 'single-page-documentation', [category: 'Documentation', iframeTarget: 'https://docs.grails.org/latest/']
+    page 'singlepagedocumentation', 'single-page-documentation', [category: 'Documentation', iframeTarget: 'http://docs.grails.org/latest/']
     page 'plugins-template', 'templates/plugins', [:]
 }
 


### PR DESCRIPTION
This fixes the single page documentation.

<img width="1380" alt="screen shot 2016-09-15 at 3 36 58 pm" src="https://cloud.githubusercontent.com/assets/1625920/18570022/8443e26e-7b5b-11e6-982e-e2a994ae2737.png">
