### PR TITLE
Mention Spring Boot as core of modern Grails.

### DIFF
--- a/site/gradle/templates/deadlinks.groovy
+++ b/site/gradle/templates/deadlinks.groovy
@@ -3,7 +3,7 @@ html {
         title 'Dead links report'
         link rel:'stylesheet', type:'text/css', href:'../site/css/style.css'
     }
-    body {
+    body(style: "background:white !important") {
         h1('Dead links report')
         if (!deadLinks) {
             p("No dead link found. All green!")

--- a/site/src/site/assets/css/style.css
+++ b/site/src/site/assets/css/style.css
@@ -116,11 +116,12 @@ a.navbar-brand {
 #band {
     /*grey =#808080*/
     background: #79B94C  no-repeat 50% 30%;
-    height: 400px;
+    height: 300px;
 }
 
 .svg #band {
     background-image: url(../img/grails-cupsonly-logo-white.svg);
+    background-size: 50%;
 }
 
 .no-svg #band {
@@ -507,7 +508,7 @@ h8 {
 
 .band {
     background: #4298b8;
-    height: 400px;
+    height: 300px;
     margin-bottom: 20px;
     color: white
 }
@@ -569,10 +570,11 @@ h8 {
     clear: both
 }
 
-#content .colset-2-its > h1 {
+#content .colset-2-its > h2 {
     padding-bottom: 15px;
     margin-top: 15px;
-    margin-bottom: 0
+    margin-bottom: 0;
+    text-align: center;
 }
 
 #content .colset-2-its > p {

--- a/site/src/site/html/index.html
+++ b/site/src/site/html/index.html
@@ -1,5 +1,5 @@
     <section class="row colset-2-its">
-        <h1>A powerful Groovy-based web application framework for the JVM</h1>
+        <h2>A powerful Groovy-based web application framework for the JVM built on top of Spring Boot</h2>
 
         <p>
             <strong>Grails</strong> is a <strong>powerful</strong> web framework, for the Java platform
@@ -41,7 +41,7 @@
                 <h1>Powerful features</h1>
 
                 <p>
-                    Integrated ORM / NoSQL support, a powerful view technology, plugins, and Spring-powered dependency injection. All you need to build modern web applications.
+                    Integrated ORM / NoSQL support, a powerful view technology, plugins, and Spring-powered dependency injection. Grails 3 which is built on top of Spring Boot facilitates building Microservices seamlessly.
                 </p>
             </article>
             <article>


### PR DESCRIPTION
As Spring Boot is the core of Grails 3, it will be helpful if Spring Boot is mentioned in Grails website. Any Spring / Java developer looking at this website would get a clear impression that Grails 3 is built on top of Spring Boot, so he/she would get everything what Spring Boot has to provide plus some added advantage/powerful features of using Groovy, Convention-over-Configuration, plugins etc.

This is small step to bring Grails closer to a Spring Boot developer.