### PR TITLE
Fixed issue with currentStableVersion always being the latest deployed.

### DIFF
--- a/site/src/site/sitemap.groovy
+++ b/site/src/site/sitemap.groovy
@@ -55,10 +55,9 @@ pages {
 }
 
 def readVersions = getClass().getResource("versions").text.split('\n')
-def previousVersions = []
-previousVersions.addAll( readVersions[0..-2])
-def currentStableVersion = readVersions[-1]
-def allVersions = previousVersions + [currentStableVersion]
+List allVersions = readVersions.sort()
+def currentStableVersion = allVersions.last()
+List previousVersions = allVersions - currentStableVersion
     
 documentation {
     groovyDocumentationVersions(allVersions)


### PR DESCRIPTION
The `currentStableVersion` used to be always the last in the list.  Sorting the available versions fixes this issue 