### PR TITLE
order versions numerically

### DIFF
--- a/site/src/site/pages/download.groovy
+++ b/site/src/site/pages/download.groovy
@@ -134,7 +134,18 @@ layout 'layouts/main.groovy', true,
 
                                 select(class: 'form-control', onchange: "window.location.href='https://github.com/grails/grails-core/releases/download/v'+ this.value +'/grails-' + this.value + '.zip'") {
                                     option(label: 'Select a version', disabled: 'disabled', 'selected': 'selected')
-                                    distributions.findAll { it.name }.each{ dist ->
+                                    distributions.findAll { it.name }.sort { lhs, rhs ->
+
+                                        // This assumes a format of major.minor.bugfix[.{RC,M}#]
+                                        def versionHash = { version ->
+                                            def parts = version.tokenize('.')
+                                            while (parts.size() < 4) { parts << null }
+
+                                            parts.collect { it == null ? '99999999' : it.padLeft(8, '0') }.join()
+                                        }
+
+                                        versionHash(rhs.packages.first().version) <=> versionHash(lhs.packages.first().version)
+                                    }.each { dist ->
                                        option "${dist.packages.first().version}"
                                     }
                                 }


### PR DESCRIPTION
This will sort the versions in the dropdown menu so that, for example, 3.2.10 will appear adjacent to 3.2.9 rather than 3.2.1.

It's very quick-n-dirty comparison, using string comparisons. It keeps the RC# and M# in their proper order (though if the # of those ever went above 9, it would break again).  It expects the version number structuring won't change significantly.

As said, it's quick and dirty, intended as a quick fix for issue #68 .  If this is too dirty, feel free to reject.