### PR TITLE
Fixes #videos link

### DIFF
--- a/site/src/site/pages/learn.groovy
+++ b/site/src/site/pages/learn.groovy
@@ -52,7 +52,7 @@ layout 'layouts/main.groovy', true,
                                 p """
                                      ${$a(href: 'http://guides.grails.org', 'Grails guides')}, 
                                      ${$a(href: '#onlinetraining', 'courses')}, ${$a(href: '#books', 'books')},
-                                     or ${$a(href: '#presentations', 'presentations')}, given about Grails at conferences, are excellent resources 
+                                     or ${$a(href: '#videos', 'presentations')}, given about Grails at conferences, are excellent resources 
                                      to learn more about Grails as well. 
                                 """
                             


### PR DESCRIPTION
Inside [Grails - Learn](https://grails.org/learn.html#presentations), `learn.html#presentations` is broken. I fixed it pointing it to `learn.html#videos`