### PR TITLE
Fix rendering of Guides footer

### DIFF
--- a/guides/src/main/groovy/org/grails/guides/pages/GuidesPage.groovy
+++ b/guides/src/main/groovy/org/grails/guides/pages/GuidesPage.groovy
@@ -329,23 +329,19 @@ class GuidesPage extends Page implements ReadFileUtils {
                     }
                 }
             }
-            div(class: 'twocolumns') {
-                div(class: 'column') {
-                    if ( !(tag || category) ) {
+            if ( !(tag || category) ) {
+                div(class: 'twocolumns') {
+                    div(class: 'column') {
                         mkp.yieldUnescaped guideGroupByCategory(categories().advanced, guides, true, 'margin-top: 0;')
                     }
-                }
-                div(class: 'column') {
-                    if ( !(tag || category) ) {
+                    div(class: 'column') {
                         mkp.yieldUnescaped guideGroupByCategory(categories().gorm, guides, true, 'margin-top: 0;')
                         mkp.yieldUnescaped guideGroupByCategory(categories().testing, guides)
 
                     }
                 }
-            }
-            div(class: 'twocolumns') {
-                div(class: 'column') {
-                    if ( !(tag || category) ) {
+                div(class: 'twocolumns') {
+                    div(class: 'column') {
                         mkp.yieldUnescaped guideGroupByCategory(categories().devops, guides)
                         mkp.yieldUnescaped guideGroupByCategory(categories().async, guides, true, 'margin-top: 0;')
                         mkp.yieldUnescaped guideGroupByCategory(categories().googlecloud, guides)
@@ -353,9 +349,7 @@ class GuidesPage extends Page implements ReadFileUtils {
                         mkp.yieldUnescaped guideGroupByCategory(categories().android, guides)
                         mkp.yieldUnescaped guideGroupByCategory(categories().ria, guides)
                     }
-                }
-                div(class: 'column') {
-                    if ( !(tag || category) ) {
+                    div(class: 'column') {
                         mkp.yieldUnescaped guideGroupByCategory(categories().vue, guides)
                         mkp.yieldUnescaped guideGroupByCategory(categories().angular, guides, true, 'margin-top: 0;')
                         mkp.yieldUnescaped guideGroupByCategory(categories().angularjs, guides)


### PR DESCRIPTION
Work around unclosed div tags by not rendering elements that will have no content.

![image](https://user-images.githubusercontent.com/695452/62083451-fa55bb00-b224-11e9-9a5d-98dd532b83a3.png)
vs.
![image](https://user-images.githubusercontent.com/695452/62083497-12c5d580-b225-11e9-89ac-9073d33b2c2a.png)

