### PR TITLE
Fix older version display

### DIFF
--- a/main/src/main/groovy/org/grails/main/SiteMap.groovy
+++ b/main/src/main/groovy/org/grails/main/SiteMap.groovy
@@ -38,7 +38,7 @@ class SiteMap {
                     new Profile(title: 'React', docsHref: 'https://grails-profiles.github.io/react/latest/guide/index.html'),
                     new Profile(title: 'React-Webpack', docsHref: 'https://grails-profiles.github.io/react-webpack/latest/guide/index.html'),
                     new Profile(title: 'Webpack', docsHref: 'https://grails-profiles.github.io/webpack/latest/guide/index.html'),
-                    new Profile(title: 'Vue', docsHref: 'https://grails-profiles.github.io/vue/latest/guide/index.html'),                
+                    new Profile(title: 'Vue', docsHref: 'https://grails-profiles.github.io/vue/latest/guide/index.html'),
     ])
 
     public final static ProfileGroup PLUGIN_PROFILES = new ProfileGroup(title: 'Plugin Profiles', image: 'images/profiles.svg',
@@ -128,7 +128,7 @@ class SiteMap {
     }
 
     static List<String> olderVersions() {
-        stableVersions().reverse().drop(1).collect { it.versionText }
+        stableVersions().drop(1).reverse().collect { it.versionText }
     }
 
     static List<SoftwareVersion> preReleaseVersions() {

--- a/main/src/main/groovy/org/grails/main/pages/DocumentationPage.groovy
+++ b/main/src/main/groovy/org/grails/main/pages/DocumentationPage.groovy
@@ -37,7 +37,7 @@ class DocumentationPage extends Page {
 
     GuideGroup documentationGuideGroup() {
         SoftwareVersion version = SiteMap.latestVersion()
-        new GuideGroup(title: "Latest Version(${version.versionText}) Documentation",
+        new GuideGroup(title: "Latest Version (${version.versionText}) Documentation",
         image: "${getImageAssetPreffix()}documentation.svg",
         items: [
                 new GuideGroupItem(href: "${docsUrl()}/${version.versionText}/guide/single.html", title: 'Single Page - User Guide'),
@@ -87,7 +87,7 @@ class DocumentationPage extends Page {
                         h3(class: "columnheader", style: 'margin-bottom: 10px;') {
                             mkp.yieldUnescaped('Older Versions')
                         }
-                        p 'Browse previous versions\' documentation since Grails 1.2.0'
+                        p "Browse previous versions' documentation since Grails ${olderVersions.last()}"
                         div(class: "versionselector") {
                             h4 'Single Page - User Guide'
                             select(onchange: "window.location.href='http://grails.org/doc/' + this.value + '/guide/single.html'") {

--- a/main/src/main/groovy/org/grails/main/pages/DownloadPage.groovy
+++ b/main/src/main/groovy/org/grails/main/pages/DownloadPage.groovy
@@ -40,15 +40,17 @@ class DownloadPage extends Page {
 
     @CompileDynamic
     String olderVersions() {
+        List<String> olderVersions = SiteMap.olderVersions()
+
         StringWriter writer = new StringWriter()
         MarkupBuilder html = new MarkupBuilder(writer)
         html.div(class: "transparent_post", style: 'margin-top: 0;') {
             h3 class: "columnheader", 'Older Versions'
-            p "You can download previous versions as far back as Grails ${SiteMap.stableVersions().last()}."
+            p "You can download previous versions as far back as Grails ${olderVersions.first()}."
             div(class: "versionselector") {
                 select(class: "form-control", onchange: "window.location.href='https://github.com/grails/grails-core/releases/download/v'+ this.value +'/grails-' + this.value + '.zip'") {
                     option label: "Select a version", disabled: "disabled", selected: "selected"
-                    for (String version : SiteMap.olderVersions()) {
+                    for (String version : olderVersions) {
                         option version
                     }
                 }


### PR DESCRIPTION
Drop the latest version instead of the first version and consistently use `olderVersions` for the oldest version source.

Also fix a display error on the download page:
![image](https://user-images.githubusercontent.com/695452/62083939-0ee68300-b226-11e9-9b77-4f876eca94fe.png)
