### PR TITLE
Created mailing list form

### DIFF
--- a/main/src/main/resources/form-mailing-list-subscribe
+++ b/main/src/main/resources/form-mailing-list-subscribe
@@ -1,0 +1,10 @@
+<!--[if lte IE 8]>
+<script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2-legacy.js"></script>
+<![endif]-->
+<script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2.js"></script>
+<script>
+  hbspt.forms.create({
+	portalId: "4547412",
+	formId: "d871e9e1-5b70-4dbb-947a-8809b1220caf"
+});
+</script>


### PR DESCRIPTION
We are migrating our marketing automation assets over to HubSpot. This form allows users to subscribe to receive updates about Grails and related technologies. 

We will probably want to add this form to the blog pages, once the blog has been moved over. No sales person will follow up with users who submit this form; they are simply added to the mailing list.