### PR TITLE
deleted wayward URL

### DIFF
--- a/posts/2016-06-02.md
+++ b/posts/2016-06-02.md
@@ -5,7 +5,6 @@ author: Jeff Scott Brown
 image: 2016-06-02.jpg
 video: https://www.youtube.com/watch?v=wVpEsbzMj90    
 ---
-http://localhost/grails/blog/2016-06-07.jpg
 # [%title]
 
 [%author]


### PR DESCRIPTION
This URL was floating at the top of the post. I'm not sure how it got there. I removed it. http://localhost/grails/blog/2016-06-07.jpg