### PR TITLE
replaced logo, added copyright

### DIFF
--- a/templates/document.html
+++ b/templates/document.html
@@ -58,7 +58,7 @@
         <div class='ocihometograils'>
             <span>Sponsored by</span>
             <a href='https://objectcomputing.com/products/grails/'><img class='' src='[%url]/images/oci-logo.svg' alt='Object Computing is proud to be home to  the Grails framework' width='300px' /></a>
-            <span>&copy; Object Computing, Inc. All rights reserved.</span>
+            <span>&copy; 2021 Object Computing, Inc. All rights reserved.</span>
         </div>
         <nav class='socialmedianav'><ul>
             <li>

--- a/templates/document.html
+++ b/templates/document.html
@@ -57,7 +57,8 @@
     <div class='content'>
         <div class='ocihometograils'>
             <span>Sponsored by</span>
-            <a href='https://objectcomputing.com/products/grails/'><img class='' src='[%url]/images/oci_home_to_grails.svg' alt='Object Computing - Home to Grails' width='300px' /></a>
+            <a href='https://objectcomputing.com/products/grails/'><img class='' src='[%url]/images/oci-logo.svg' alt='Object Computing is proud to be home to  the Grails framework' width='300px' /></a>
+            <span>&copy; Object Computing, Inc. All rights reserved.</span>
         </div>
         <nav class='socialmedianav'><ul>
             <li>


### PR DESCRIPTION
We can no longer use the "Home to Grails" logo, so I replaced the logo in the footer with a basic Object Computing logo.
I also added "&copy; Object Computing, Inc. All rights reserved." below the logo.
Please confirm that I added the text correctly. I saw that "Sponsored by" was designated with &lt;span&gt; instead of &lt;p&gt;, so that's what I used for the copyright, as well.