### PR TITLE
update copyright statement in footer

### DIFF
--- a/templates/document.html
+++ b/templates/document.html
@@ -58,7 +58,7 @@
         <div class='ocihometograils'>
             <span>Sponsored by</span>
             <a href='https://objectcomputing.com/products/grails/'><img class='' src='[%url]/images/oci-logo.svg' alt='Object Computing is proud to be home to  the Grails framework' width='300px' /></a>
-            <span>&copy; 2021 Object Computing, Inc. All rights reserved.</span>
+            <span>&copy; 2021 Grails Foundation. All rights reserved.</span>
         </div>
         <nav class='socialmedianav'><ul>
             <li>


### PR DESCRIPTION
Changed copyright statement in footer from (c) Object Computing, Inc. to (c) Grails Foundation