### PR TITLE
Update Publish Grails Plugin to Maven Central Blog

### DIFF
--- a/posts/2021-04-07-publish-grails-plugin-to-maven-central.md
+++ b/posts/2021-04-07-publish-grails-plugin-to-maven-central.md
@@ -178,7 +178,7 @@ grailsPublish {
       
    3. Get Signatory Credentials
       1. Get the public key ID (The last 8 symbols using `gpg -K` command).
-      2. Export the keys with command `gpg -keyring secring.gpg --export-secret-keys > ~/.gnupg/secring.gpg`.
+      2. Export the keys with command `gpg --keyring secring.gpg --export-secret-keys > ~/.gnupg/secring.gpg`.
       3. Know the Passphrase used to protect private keys.
     
    4. Export the following environment variables


### PR DESCRIPTION
Fix incorrect command to export GPG key from `-keyring` to `--keyring`.