### PR TITLE
Adjusted image size

### DIFF
--- a/pages/foundation/sponsor-list.html
+++ b/pages/foundation/sponsor-list.html
@@ -14,7 +14,7 @@ body: foundation-sponsors
         <h2 class="sponsor-group-title">Our Ambassador</h2>
         <div class="sponsor-group-member">
             <a href="https://objectcomputing.com">
-                <img src="/images/sponsor/oci-sponsor.png" alt="Object Computing - Home to Grails" />
+                <img src="/images/sponsor/oci-sponsor.png" alt="Object Computing is proud to be home to the Grails framework" />
             </a>
         </div>
     </div>
@@ -23,7 +23,7 @@ body: foundation-sponsors
         <h2 class="sponsor-group-title">Gold Sponsor</h2>
         <div class="sponsor-group-member">
             
-            <img src="/images/corporatesponsor.svg" alt="Anonymous Gold-Level Sponsor" />
+            <img src="/images/corporatesponsor.svg" alt="Anonymous Gold-Level Sponsor" style="max-width:200px;" />
             <p style="margin-top:15px;">
                 Anonymous Gold-Level Sponsor
             </p>


### PR DESCRIPTION
I adjusted the size of the Gold sponsor icon because it looked really big at 350px. Also updated the alt text for the OCI logo to include "framework" while I was in here.