### PR TITLE
Fix Links in Guides' Headers

### DIFF
--- a/buildSrc/src/main/groovy/org/grails/Page.groovy
+++ b/buildSrc/src/main/groovy/org/grails/Page.groovy
@@ -10,7 +10,7 @@ class Page implements Content {
 
     @Override
     String getPath() {
-        filename
+        filename?.replaceAll('\\\\', '/')
     }
 
     @Override

--- a/buildSrc/src/main/groovy/org/grails/guides/GuidesPage.groovy
+++ b/buildSrc/src/main/groovy/org/grails/guides/GuidesPage.groovy
@@ -265,7 +265,7 @@ class GuidesPage {
             div(class: "guidegroupheader") {
                 img src: "[%url]/images/${category.image}" as String, alt: category.name
                 if ( linkToCategory )  {
-                    a(href: "[%url]/categories/${category.slug}.html") {
+                    a(href: "${GUIDES_URL}/categories/${category.slug}.html") {
                         h2 category.name
                     }
                 } else {


### PR DESCRIPTION
- Fixes the link in the headers of the various Guides.
- Fixes an issue where build would fail in Windows

Fixes issue #195