### PR TITLE
Don't rely on http->https redirects for web links.

### DIFF
--- a/buildSrc/src/main/groovy/org/grails/documentation/DocumentationPage.groovy
+++ b/buildSrc/src/main/groovy/org/grails/documentation/DocumentationPage.groovy
@@ -91,21 +91,21 @@ class DocumentationPage {
 
                         div(class: 'versionselector') {
                             h4 'Single Page - User Guide'
-                            select(onchange: "window.location.href='http://grails.org/doc/' + this.value + '/guide/single.html'") {
+                            select(onchange: "window.location.href='https://grails.org/doc/' + this.value + '/guide/single.html'") {
                                 option 'Select a version'
                                 mkp.yield('[%versions]')
                             }
                         }
                         div(class: 'versionselector') {
                             h4 'User Guide'
-                            select(onchange: "window.location.href=&apos;http://grails.org/doc/&apos; + this.value") {
+                            select(onchange: "window.location.href=&apos;https://grails.org/doc/&apos; + this.value") {
                                 option 'Select a version'
                                 mkp.yield('[%versions]')
                             }
                         }
                         div(class: 'versionselector') {
                             h4 'API Reference'
-                            select(onchange: "window.location.href=&apos;http://grails.org/doc/&apos; + this.value + &apos;/api&apos;") {
+                            select(onchange: "window.location.href=&apos;https://grails.org/doc/&apos; + this.value + &apos;/api&apos;") {
                                 option 'Select a version'
                                 mkp.yield('[%versions]')
                             }

--- a/pages/community.html
+++ b/pages/community.html
@@ -119,7 +119,7 @@ title: Community | Grails&reg; Framework
                 </div>
                 <ul>
                     <li>
-                        <a href="http://www.grailsbrasil.com.br/">Brazil - Grails Brasil - Groovy and Grails users group</a>
+                        <a href="https://www.grailsbrasil.com.br/">Brazil - Grails Brasil - Groovy and Grails users group</a>
                     </li>
                 </ul>
             </div>

--- a/pages/index.html
+++ b/pages/index.html
@@ -27,7 +27,7 @@ body: home
         <div class="get-started-row">
             <div class="calltoaction">
                 <h2>
-                    <a href="http://start.grails.org/">
+                    <a href="https://start.grails.org/">
                         <span class="version">Get Started</span>
                     </a>
                 </h2>

--- a/pages/privacy-policy.html
+++ b/pages/privacy-policy.html
@@ -182,7 +182,7 @@ title: Privacy Policy | Grails&reg; Framework
         </p>
 
         <p>
-            If you no longer wish to be contacted for marketing purposes, please visit <a href="https://www.google.com/url?q=http://hs-4547412.s.hubspotemail.net/hs/manage-preferences/unsubscribe-simple&amp;source=gmail-html&amp;ust=1631984980983000&amp;usg=AFQjCNE7C0QCEKI_cPCwVTo5bUoNKEEZGQ" target="_blank" rel="noreferrer">http://hs-4547412.s.<wbr>hubspotemail.net/hs/manage-<wbr>preferences/unsubscribe-simple</a><wbr>.
+            If you no longer wish to be contacted for marketing purposes, please visit <a href="https://www.google.com/url?q=https://hs-4547412.s.hubspotemail.net/hs/manage-preferences/unsubscribe-simple&amp;source=gmail-html&amp;ust=1631984980983000&amp;usg=AFQjCNE7C0QCEKI_cPCwVTo5bUoNKEEZGQ" target="_blank" rel="noreferrer">http://hs-4547412.s.<wbr>hubspotemail.net/hs/manage-<wbr>preferences/unsubscribe-simple</a><wbr>.
         </p>
 
         <a id="protection-rights" rel="noreferrer"></a>


### PR DESCRIPTION
I noticed the docks point to `http://start.grails.org/` which does not have a https redirect.
This means users will be using unsecured links.

**CHANGE**
Scanned entire doc site and Convert URL explicitly to using https.

In all but one case redirects are present on target websites,
however over time load balances can be configured in correctly.
Hence its better not to rely on redirects for security purposes.

**Testing:**
   Manually entered https URL into browser to ensure it was supported.