### PR TITLE
Change YouTube footer link to Grails Framework channel

### DIFF
--- a/templates/document.html
+++ b/templates/document.html
@@ -70,7 +70,7 @@
                     <a href='https://slack.grails.org'><img class='' src='[%url]/images/slack.svg' alt='Slack Icon' /></a>
                 </li>
                 <li>
-                    <a href='https://www.youtube.com/watch?v=XnRNfDGkBVg&amp;list=PLI74De5M9T73uH3WilDCePP2qfSDpMaGu'><img class='' src='[%url]/images/youtube.svg' alt='Youtube Icon' /></a>
+                    <a href='https://www.youtube.com/@GrailsFramework'><img class='' src='[%url]/images/youtube.svg' alt='Youtube Icon' /></a>
                 </li>
                 <li>
                     <a href='https://www.linkedin.com/showcase/official-grails/'><img class='' src='[%url]/images/linkedin.svg' alt='LinkedIn Icon' /></a>


### PR DESCRIPTION
The YouTube icon/link in the footer is changed to point to the YouTube channel rather than a particular video.
