### PR TITLE
Make all plugins list unmodifiable and always run op on copy

### DIFF
--- a/buildSrc/src/main/groovy/org/grails/gradle/PluginsTask.groovy
+++ b/buildSrc/src/main/groovy/org/grails/gradle/PluginsTask.groovy
@@ -126,7 +126,7 @@ class PluginsTask extends DefaultTask {
                     githubStars: githubStars(json[i].bintrayPackage.vcsUrl).orElse(null),
                     labels: json[i].bintrayPackage.labels as List<String>))
         }
-        plugins
+        Collections.unmodifiableList(plugins)
     }
 
     LocalDateTime parseIsoStringToDate(String isoFormattedString){

--- a/buildSrc/src/main/groovy/org/grails/plugin/PluginsPage.groovy
+++ b/buildSrc/src/main/groovy/org/grails/plugin/PluginsPage.groovy
@@ -8,6 +8,7 @@ import org.grails.guides.TagUtils
 import org.grails.tags.Tag
 import org.grails.tags.TagCloud
 import java.time.format.DateTimeFormatter
+import java.util.stream.Collector
 import java.util.stream.Collectors
 
 @CompileStatic
@@ -56,7 +57,7 @@ class PluginsPage {
             div(class: 'twocolumns') {
                 div(class: 'column') {
                     mkp.yieldUnescaped searchBox(null, null)
-                    //mkp.yieldUnescaped latestPlugins(siteUrl, plugins)
+                    mkp.yieldUnescaped latestPlugins(siteUrl, plugins)
                     mkp.yieldUnescaped topRatedPlugins(siteUrl, plugins)
                     mkp.yieldUnescaped pluginsByTag(siteUrl, plugins)
                     mkp.yieldUnescaped pluginsByOwner(siteUrl, plugins)
@@ -292,8 +293,10 @@ class PluginsPage {
 
     @CompileDynamic
     static String fetchLatestPlugins(String siteUrl, List<Plugin> plugins) {
-        plugins.sort(COMPARE_BY_UPDATED)
-        List<Plugin> topFive = plugins.take(5)
+        final List<Plugin> sortedPlugins = plugins.stream()
+                .sorted(COMPARE_BY_UPDATED)
+                .collect(Collectors.toList())
+        final List<Plugin> topFive = sortedPlugins.take(5)
         renderLatestPlugins(siteUrl, topFive)
     }
 


### PR DESCRIPTION
Update the implementation of method to find top five latest plugin, to sort the copy of plugins List and also make the global plugins list unmodifiable.