### PR TITLE
[Grails Guides] Render category names properly

### DIFF
--- a/buildSrc/src/main/groovy/org/grails/gradle/GuidesTask.groovy
+++ b/buildSrc/src/main/groovy/org/grails/gradle/GuidesTask.groovy
@@ -132,7 +132,7 @@ class GuidesTask extends DefaultTask {
             String slug = "${category.slug.toLowerCase()}.html"
             pageOutput = new File(categoriesDir.getAbsolutePath() + "/" + slug)
             pageOutput.createNewFile()
-            pageOutput.text = "---\ntitle: Guides at category ${category} | Grails Framework\nbody: guides\n---\n" + GuidesPage.mainContent(classLoader, guides, tags, category, null)
+            pageOutput.text = "---\ntitle: Guides at category ${category.name} | Grails Framework\nbody: guides\n---\n" + GuidesPage.mainContent(classLoader, guides, tags, category, null)
         }
     }
 }


### PR DESCRIPTION
@puneetbehl I noticed category names are being published incorrectly in Grails Guides.

For example, [this commit](https://github.com/grails/grails-guides/commit/c09bd11b5344101bcec41f6261c15e0c8fc611d3#diff-2133a85c1c844954670ff882e0efa6750d134ebf35ec791fbb093e976f79b9f1R4) makes https://guides.grails.org/categories/advancedgrails.html render page title as:

> *Guides at category **org.grails.guides.Category@60e9c3b5** | Grails Framework*

Instead of:

> *Guides at category **Advanced Grails** | Grails Framework*

This PR stops invoking unimplemented `Category::toString`.
