### PR TITLE
Publish websites every 2nd hour

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
   schedule:
-    - cron:  '* 9 * * *'
+    - cron:  '0 */2 * * *'
   workflow_dispatch:
 jobs:
   build:


### PR DESCRIPTION
@puneetbehl According to `crontab.guru`, [Publish action](https://github.com/grails/grails-static-website/actions/workflows/publish.yml) is currently scheduled as [*“At every minute past hour 9”*](https://crontab.guru/#*_9_*_*_*), which I believe must have been made by mistake 🤔

This PR will make the Publish action trigger [every 2 hours](https://crontab.guru/#0_*/2_*_*_*). I hope that's a sensible scheduling, but please feel free to adjust it as you see fit.
