### PR TITLE
Sort sitemap URLs

### DIFF
--- a/buildSrc/src/main/groovy/org/grails/gradle/SitemapTask.groovy
+++ b/buildSrc/src/main/groovy/org/grails/gradle/SitemapTask.groovy
@@ -33,7 +33,7 @@ class SitemapTask extends DefaultTask {
         }
         File outputFile = new File(inputFile.absolutePath + "/" + FILE_SITEMAP)
         outputFile.createNewFile()
-        outputFile.text = sitemapContent(urls)
+        outputFile.text = sitemapContent(urls.sort())
     }
 
     @CompileDynamic


### PR DESCRIPTION
[Every time `sitemap.xml` is generated](https://github.com/grails/grails-guides/commits/gh-pages), the URLs appear in random order.

This PR makes sure sitemap contents are properly sorted, so that Publish action doesn't push changes to `gh-pages` unless there are actual changes.