### PR TITLE
Add Kapa AI assistant widget to Grails Website

### DIFF
--- a/templates/document.html
+++ b/templates/document.html
@@ -50,6 +50,28 @@
       })();
     </script>
     <!-- End Matomo Code -->
+
+    <script
+        async
+        src="https://widget.kapa.ai/kapa-widget.bundle.js"
+        data-website-id="d804a9f2-51a2-414c-97f7-12f2a1ba4609"
+        data-project-name="Apache Grails"
+        data-project-color="#3F4346"
+        data-font-family="system-ui,-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,Segoe UI,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;"
+        data-project-logo="https://grails.apache.org/images/grails.png"
+        data-modal-override-open-id="ask-ai-input"
+        data-modal-override-open-class="search-input"
+        data-user-analytics-fingerprint-enabled="true"
+        data-modal-title="Apache Grails AI Assistant"
+        data-modal-example-questions-title="Try asking me..."
+        data-modal-disclaimer="This is a custom LLM for Apache Grails using [documentation](https://docs.grails.org/latest/), [groovy documentation](https://docs.groovy-lang.org/docs/groovy-4.0.28/html/documentation/) [github issues](https://github.com/apache/grails-core/issues) and more.\n\nCompanies deploy assistants like this [](https://kapa.ai) on docs via [website widget](https://docs.kapa.ai/integrations/website-widget) (Docker, Reddit), in [support forms](https://docs.kapa.ai/integrations/support-form-deflector) for ticket deflection (Monday.com, Mapbox), or as [an internal assistant](https://docs.kapa.ai/integrations/internal-assistant) with access to private sources."
+        data-modal-example-questions="How does database migration work?,How does Spring Security work?"
+        data-button-text-color="#FBB576"
+        data-modal-header-bg-color="#FFFFFF"
+        data-modal-title-color="#FBB576"
+        data-consent-required="true"
+        data-consent-screen-disclaimer="By clicking &quot;I agree, let&#39;s chat&quot;, you consent to the use of the AI assistant in accordance with kapa.ai&#39;s [Privacy Policy](https://www.kapa.ai/content/privacy-policy). This service uses reCAPTCHA, which requires your consent to Google&#39;s [Privacy Policy](https://policies.google.com/privacy) and [Terms of Service](https://policies.google.com/terms). By proceeding, you explicitly agree to both kapa.ai&#39;s and Google&#39;s privacy policies.">
+    ></script>
 </head>
 <body>
 <header class='mainheader'>


### PR DESCRIPTION
Integrate the Kapa AI assistant widget by adding its script tag with relevant configuration attributes to the document.html template. This provides users with an AI-powered assistant for Apache Grails documentation.

Modeled after https://hudi.apache.org/ integration 

Preview Widget: https://demo.kapa.ai/widget/apache-grails