### PR TITLE
Add custom 404 error page and update htaccess

### DIFF
--- a/buildSrc/src/main/groovy/org/grails/gradle/HtaccessTask.groovy
+++ b/buildSrc/src/main/groovy/org/grails/gradle/HtaccessTask.groovy
@@ -40,6 +40,9 @@ class HtaccessTask extends DefaultTask {
         ]
 
     private static String HT_ACCESS_CONTENT =
+            '# Custom 404 error page\n' +
+            'ErrorDocument 404 /404.html\n' +
+            '\n' +
             '# CSP permissions for grails.apache.org - https://issues.apache.org/jira/browse/INFRA-27297\n' +
             '# Ref https://docs.kapa.ai/integrations/understanding-csp-cors\n' +
             'SetEnv CSP_PROJECT_DOMAINS "' + DOMAINS.join(' ') + '"'

--- a/pages/404.html
+++ b/pages/404.html
@@ -1,0 +1,28 @@
+title: Page Not Found | Grails&reg; Framework
+CSS: /stylesheets/support.css
+---
+<div class='headerbar chalicesbg'>
+    <div class='content'>
+        <h1>404 - Page Not Found</h1>
+    </div>
+</div>
+<div class='content'>
+    <article>
+        <p class="intro_copy">
+        <h2>Oops! The page you're looking for doesn't exist.</h2>
+        <p>The page you are trying to access might have been removed, had its name changed, or is temporarily unavailable.</p>
+
+        <h2>What can you do?</h2>
+        <ul>
+            <li>Check the URL for typing errors</li>
+            <li>Return to the <a href="/">home page</a></li>
+            <li>Visit our <a href="/learning.html">learning resources</a></li>
+            <li>Explore the <a href="/community.html">Grails community</a></li>
+        </ul>
+
+        <h2>Need Help?</h2>
+        <p>If you believe this is an error or need assistance, please reach out to the Grails community through our
+            <a href="/community.html">community channels</a> or check our <a href="/support.html">support options</a>.</p>
+    </article>
+</div>
+


### PR DESCRIPTION
Introduced a new 404.html page for handling not found errors and updated HtaccessTask to serve this custom page for 404 errors. This improves user experience by providing a branded error page and clearer guidance when a page is missing.