### PR TITLE
Update footer year

### DIFF
--- a/templates/document.html
+++ b/templates/document.html
@@ -149,7 +149,7 @@ Companies deploy assistants like this [](https://kapa.ai) on docs via [website w
     </div>
     <div class="content">
         <nav class='footer' style="margin-bottom: 10px">
-                <p>© 2005-2025 the Apache Grails project — Grails is Open Source: 
+                <p>© 2005-2026 the Apache Grails project — Grails is Open Source: 
                     <a href='https://www.apache.org/licenses/'>License</a>,
                     <a href='https://privacy.apache.org/policies/privacy-policy-public.html'>Privacy Policy</a>,
                     <a href='https://www.apache.org/foundation/sponsorship'>Sponsor Apache</a>,


### PR DESCRIPTION
# Changes I made:
- The website footer displayed the copyright range as © 2005-2025. Since we are now in 2026, this is technically outdated.
 I updated the text to © 2005-2026 in `templates/document.html`

This PR resolves issue #408 