### PR TITLE
chore: remove stale TODOs and dead code

### DIFF
--- a/pages/community.html
+++ b/pages/community.html
@@ -122,17 +122,7 @@ title: Community | Apache Grails&reg; Framework
         </div>
 
     </article>
-    <!--    TODO These events didn't end up happening, would have been past, and the copy is off.-->
-    <!--    <article>-->
-    <!--        <h3 class="column-header">Conferences</h3>-->
-    <!--        <p>The Grails framework and its ecosystem are often represented at various Java-oriented conferences, but there are particular events fully dedicated to the Groovy/Grails ecosystem. Here are the upcoming events you might be interested in learning about.</p><div class="two-columns">-->
-    <!--        <div class="column"><div class="event">-->
-    <!--            <img src="[%url]/images/confs/gr8confeu.png" alt="GR8Conf EU 2020">-->
-    <!--            <h3>-->
-    <!--                <a href="https://gr8conf.eu/">GR8Conf EU 2020</a>-->
-    <!--            </h3>-->
-    <!--            <span class="location">Copenhagen, Denmark</span>-->
-    <!--            <span class="dates">June 2 - 4, 2020</span><p>Groovy, the Grails framework, and related technologies have seen astounding growth in interest and adoption over the past few years, and with good reason. GR8Conf is a series of conferences founded to spread the word worldwide. The 2018 GR8Conf Europe is celebrating its 10th year, and it's expected to be a blast. As in 2017 the conference had a DevOps day, this year DevOps topics will be mixed with the rest of the topics. GR8Conf is an independent, affordable series of conferences and covers All Things Groovy</p>-->
+
 
     <h3 class="column-header" style="margin-bottom: 0">User Groups</h3>
     <div class="two-columns">
@@ -143,37 +133,11 @@ title: Community | Apache Grails&reg; Framework
                     <h2>North-America</h2>
                 </div>
                 <ul>
-                    <!--        TODO a lot of these links are broken, I've no doubt many of the communities still exist in some form but how should we proceed?        -->
-                    <!--                <li>-->
-                    <!--                    <a href="https://www.meetup.com/Austin-Groovy-and-Grails-Users/">United States - Austin Groovy and Grails User Group (TX)</a>-->
-                    <!--                </li>-->
-                    <!--                <li>-->
-                    <!--                    <a href="https://www.meetup.com/Grails-Boston/">United States - Boston Groovy, Grails, Spring Meetup (B2GS)</a>-->
-                    <!--                </li>-->
-                    <!--                <li>-->
-                    <!--                    <a href="https://coderconsortium.com/">United States - Coder Consortium of Sacramento</a>-->
-                    <!--                </li>-->
-                    <!--                <li>-->
-                    <!--                    <a href="https://www.dcgroovy.org/">United States - DC Groovy</a>-->
-                    <!--                </li>-->
-                    <!--                <li>-->
-                    <!--                    <a href="https://dfw2gug.org/">United States - DFW Groovy &amp; Grails User Group</a>-->
-                    <!--                </li>-->
-                    <!--                <li>-->
-                    <!--                    <a href="https://www.meetup.com/Grails-and-Ales/">United States - Groovy and Grails Users of Columbus OH</a>-->
-                    <!--                </li>-->
-                    <!--                <li>-->
-                    <!--                    <a href="https://groovy.mn/">United States - Groovy Users of Minnesota</a>-->
-                    <!--                </li>-->
-                    <!--                <li>-->
-                    <!--                    <a href="https://www.meetup.com/Los-Angeles-GUG/">United States - Los Angeles Groovy Users Group</a>-->
-                    <!--                </li>-->
+
                     <li>
                         <a href="https://www.meetup.com/grails/">United States - NYC Groovy / Grails Meetup</a>
                     </li>
-                    <!--                <li>-->
-                    <!--                    <a href="https://www.scottsdale-groovy.com/">United States - Scottsdale Groovy Brigade</a>-->
-                    <!--                </li>-->
+
                     <li>
                         <a href="https://www.meetup.com/java-161/">United States - SF Bay Groovy and Grails Meetup
                             Group</a>

--- a/pages/community.html
+++ b/pages/community.html
@@ -130,72 +130,10 @@ title: Community | Apache Grails&reg; Framework
             </div>
         </div>
     </article>
-    <!--    TODO These events didn't end up happening, would have been past, and the copy is off.-->
-    <!--    <article>-->
-    <!--        <h3 class="column-header">Conferences</h3>-->
-    <!--        <p>The Grails framework and its ecosystem are often represented at various Java-oriented conferences, but there are particular events fully dedicated to the Groovy/Grails ecosystem. Here are the upcoming events you might be interested in learning about.</p><div class="two-columns">-->
-    <!--        <div class="column"><div class="event">-->
-    <!--            <img loading="lazy" src="[%url]/images/confs/gr8confeu.png" alt="GR8Conf EU 2020">-->
-    <!--            <h3>-->
-    <!--                <a href="https://gr8conf.eu/">GR8Conf EU 2020</a>-->
-    <!--            </h3>-->
-    <!--            <span class="location">Copenhagen, Denmark</span>-->
-    <!--            <span class="dates">June 2 - 4, 2020</span><p>Groovy, the Grails framework, and related technologies have seen astounding growth in interest and adoption over the past few years, and with good reason. GR8Conf is a series of conferences founded to spread the word worldwide. The 2018 GR8Conf Europe is celebrating its 10th year, and it's expected to be a blast. As in 2017 the conference had a DevOps day, this year DevOps topics will be mixed with the rest of the topics. GR8Conf is an independent, affordable series of conferences and covers All Things Groovy</p>-->
 
     <h3 class="column-header" style="margin-bottom: 0">User Groups</h3>
     <div class="two-columns">
         <div class="column">
-            <div class="guide-group">
-                <div class="guide-group-header">
-                    <img loading="lazy" src="[%url]/images/usergroup.svg" alt="North-America">
-                    <h2>North-America</h2>
-                </div>
-                <ul>
-                    <!--        TODO a lot of these links are broken, I've no doubt many of the communities still exist in some form but how should we proceed?        -->
-                    <!--                <li>-->
-                    <!--                    <a href="https://www.meetup.com/Austin-Groovy-and-Grails-Users/">United States - Austin Groovy and Grails User Group (TX)</a>-->
-                    <!--                </li>-->
-                    <!--                <li>-->
-                    <!--                    <a href="https://www.meetup.com/Grails-Boston/">United States - Boston Groovy, Grails, Spring Meetup (B2GS)</a>-->
-                    <!--                </li>-->
-                    <!--                <li>-->
-                    <!--                    <a href="https://coderconsortium.com/">United States - Coder Consortium of Sacramento</a>-->
-                    <!--                </li>-->
-                    <!--                <li>-->
-                    <!--                    <a href="https://www.dcgroovy.org/">United States - DC Groovy</a>-->
-                    <!--                </li>-->
-                    <!--                <li>-->
-                    <!--                    <a href="https://dfw2gug.org/">United States - DFW Groovy &amp; Grails User Group</a>-->
-                    <!--                </li>-->
-                    <!--                <li>-->
-                    <!--                    <a href="https://www.meetup.com/Grails-and-Ales/">United States - Groovy and Grails Users of Columbus OH</a>-->
-                    <!--                </li>-->
-                    <!--                <li>-->
-                    <!--                    <a href="https://groovy.mn/">United States - Groovy Users of Minnesota</a>-->
-                    <!--                </li>-->
-                    <!--                <li>-->
-                    <!--                    <a href="https://www.meetup.com/Los-Angeles-GUG/">United States - Los Angeles Groovy Users Group</a>-->
-                    <!--                </li>-->
-                    <li>
-                        <a href="https://www.meetup.com/grails/">United States - NYC Groovy / Grails Meetup</a>
-                    </li>
-                    <!--                <li>-->
-                    <!--                    <a href="https://www.scottsdale-groovy.com/">United States - Scottsdale Groovy Brigade</a>-->
-                    <!--                </li>-->
-                    <li>
-                        <a href="https://www.meetup.com/java-161/">United States - SF Bay Groovy and Grails Meetup
-                            Group</a>
-                    </li>
-                    <li>
-                        <a href="https://www.meetup.com/st-louis-groovy-and-grails-meetup/">United States - St. Louis
-                            Groovy &amp; Grails Meetup</a>
-                    </li>
-                </ul>
-            </div>
-        </div>
-
-        <div class="column">
-
             <div class="guide-group">
                 <div class="guide-group-header">
                     <img loading="lazy" src="[%url]/images/usergroup.svg" alt="Asia">
@@ -208,7 +146,9 @@ title: Community | Apache Grails&reg; Framework
                     </li>
                 </ul>
             </div>
+        </div>
 
+        <div class="column">
             <div class="guide-group">
                 <div class="guide-group-header">
                     <img loading="lazy" src="[%url]/images/usergroup.svg" alt="Europe">


### PR DESCRIPTION
Removes large sections of commented-out HTML and outdated TODO metadata from community.html to improve source cleanliness.