### PR TITLE
Pin GitHub Actions to Apache-approved commit hashes

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -23,7 +23,7 @@ jobs:
           distribution: liberica
           java-version: 17
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
           develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       - name: Run Tests
@@ -31,7 +31,7 @@ jobs:
           (set -x; ./gradlew clean check --no-daemon)
       - name: Publish Test Report
         if: failure()
-        uses: scacap/action-surefire-report@v1
+        uses: scacap/action-surefire-report@5609ce4db72c09db044803b344a8968fd1f315da # v1.9.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
           distribution: liberica
           java-version: 17
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
           develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       - name: Publish Main Site

--- a/.github/workflows/rendersite.yml
+++ b/.github/workflows/rendersite.yml
@@ -11,7 +11,7 @@ jobs:
           java-version: 17
           distribution: liberica
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
         with:
           develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       - name: Render HTML for Site


### PR DESCRIPTION
## Summary

- Pin third-party GitHub Actions to commit hashes from [apache/infrastructure-actions approved_patterns.yml](https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml) for supply chain security compliance.

## Changes

| Workflow | Action | Before | After |
|---|---|---|---|
| `rendersite.yml` | `gradle/actions/setup-gradle` | `@v4` | `@017a9eff...` (v4.4.2) |
| `publish.yml` | `gradle/actions/setup-gradle` | `@v5` | `@07231958...` (v5.0.2) |
| `gradle.yml` | `gradle/actions/setup-gradle` | `@v5` | `@07231958...` (v5.0.2) |
| `gradle.yml` | `scacap/action-surefire-report` | `@v1` | `@5609ce4d...` (v1.9.1) |

GitHub first-party actions (`actions/checkout`, `actions/setup-java`, `actions/cache`) are not in the approved patterns file and remain on version tags.