### PR TITLE
Reclassify OpenLogic, refresh support schedule for v7.1.0 release

### DIFF
--- a/pages/support-schedule.html
+++ b/pages/support-schedule.html
@@ -86,13 +86,21 @@ description: Support schedule for the Grails&reg; application framework
                 <td>Coming Soon</td>
                 <td>Coming Soon</td>
                 <td>Dec 2026</td>
-                <td><a href="support.html">Available</a></td>
+                <td>Coming Soon</td>
             </tr>
             <tr>
-                <td>7.1</td>
+                <td>7.2</td>
                 <td>Active Development</td>
                 <td>Coming Soon</td>
                 <td>Coming Soon</td>
+                <td>Jun 2026</td>
+                <td>Coming Soon</td>
+            </tr>
+            <tr>
+                <td>7.1</td>
+                <td>Active Maintenance</td>
+                <td>Apr 2026</td>
+                <td>Ongoing</td>
                 <td>Jun 2026</td>
                 <td><a href="support.html">Available</a></td>
             </tr>
@@ -110,7 +118,7 @@ description: Support schedule for the Grails&reg; application framework
                 <td>Jul 2023</td>
                 <td>Jan 2025<br/>(6.2.3)</td>
                 <td>Jun 2025</td>
-                <td><a href="support.html">Available</a></td>
+                <td><a href="support.html">Available</a><br/>(6.2.x only)</td>
             </tr>
             <tr>
                 <td>5</td>
@@ -118,7 +126,7 @@ description: Support schedule for the Grails&reg; application framework
                 <td>Oct 2021</td>
                 <td>Jan 2024<br/>(5.3.6)</td>
                 <td>Jun 2024</td>
-                <td><a href="support.html">Available</a></td>
+                <td>Not Available</td>
             </tr>
             <tr>
                 <td>4</td>
@@ -126,7 +134,7 @@ description: Support schedule for the Grails&reg; application framework
                 <td>Jul 2019</td>
                 <td>Jan 2024<br/>(4.1.4)</td>
                 <td>Mar 2024</td>
-                <td><a href="support.html">Available</a></td>
+                <td>Not Available</td>
             </tr>
             <tr>
                 <td>3</td>
@@ -134,7 +142,7 @@ description: Support schedule for the Grails&reg; application framework
                 <td>Mar 2015</td>
                 <td>Jan 2024<br/>(3.3.18)</td>
                 <td>Sep 2021</td>
-                <td><a href="support.html">Available</a></td>
+                <td>Not Available</td>
             </tr>
             <tr>
                 <td>2</td>
@@ -142,7 +150,7 @@ description: Support schedule for the Grails&reg; application framework
                 <td>Dec 2011</td>
                 <td>Mar 2017<br/>(2.5.6)</td>
                 <td>Jun 2021</td>
-                <td><a href="support.html">Available</a></td>
+                <td>Not Available</td>
             </tr>
             <tr>
                 <td>1</td>

--- a/pages/support.html
+++ b/pages/support.html
@@ -28,7 +28,7 @@ CSS: /stylesheets/support.css
             of
             other supportive companies, please share details with us.</p>
 
-        <p>Last updated: <strong>2026-04-15</strong></p>
+        <p>Last updated: <strong>2026-04-28</strong></p>
         <ul>
             <li>Europe
                 <ul>
@@ -53,7 +53,7 @@ CSS: /stylesheets/support.css
             Versions listed below are based on each vendor's published information at the time of writing
             and are subject to change. Please confirm details directly with the vendor.</p>
 
-        <p>Last updated: <strong>2026-04-26</strong></p>
+        <p>Last updated: <strong>2026-04-28</strong></p>
         <ul>
             <li><a href="https://www.herodevs.com/support/apache-grails-nes?utm_source=Referral&amp;utm_medium=Link&amp;utm_campaign=ApacheGrailsLink&amp;utm_id=ApacheGrailsLink"
                     rel="nofollow noopener noreferrer" target="_blank">HeroDevs</a> &mdash; 6.2.x, 7.x</li>

--- a/pages/support.html
+++ b/pages/support.html
@@ -42,6 +42,8 @@ CSS: /stylesheets/support.css
                            target="_blank">Object Computing, Inc.</a></li>
                     <li><a href="https://www.triumphinteractive.com/" rel="nofollow noopener noreferrer" target="_blank">Triumph
                         Interactive, Inc.</a></li>
+                    <li><a href="https://www.openlogic.com/supported-technology?st-title=grails" rel="nofollow noopener noreferrer"
+                           target="_blank">OpenLogic</a></li>
                 </ul>
             </li>
         </ul>
@@ -55,8 +57,6 @@ CSS: /stylesheets/support.css
         <ul>
             <li><a href="https://www.herodevs.com/support/apache-grails-nes?utm_source=Referral&amp;utm_medium=Link&amp;utm_campaign=ApacheGrailsLink&amp;utm_id=ApacheGrailsLink"
                     rel="nofollow noopener noreferrer" target="_blank">HeroDevs</a> &mdash; 6.2.x, 7.x</li>
-            <li><a href="https://www.openlogic.com/supported-technology?st-title=grails" rel="nofollow noopener noreferrer"
-                    target="_blank">OpenLogic</a> &mdash; 2.x, 3.x, 4.x, 5.x, 6.x, 7.x</li>
         </ul>
 
         <h2>Extended Spring Boot Support</h2>


### PR DESCRIPTION
## Summary

Refreshes both support pages to reflect:
- OpenLogic's actual offering (general commercial support, not extended support)
- The Apache Grails 7.1.0 release (Apr 2026) and the upcoming 7.2.x line
- The realistic Extended Support landscape now that HeroDevs is the sole vendor (`6.2.x, 7.x`)

## Changes

### `pages/support.html`
- **List of companies**: Added OpenLogic (North America) alongside Object Computing, Inc. and Triumph Interactive, Inc. Bumped **Last updated** to `2026-04-28`.
- **Extended Apache Grails Support**: Removed OpenLogic. HeroDevs (`6.2.x, 7.x`) is now the sole entry. Bumped **Last updated** to `2026-04-28`.

### `pages/support-schedule.html`
With OpenLogic no longer claiming extended support across `2.x-7.x`, the **Extended Support** column was updated to reflect actual HeroDevs coverage. Also picked up the v7.1.0 release reality and added a v7.2 row.

| Version | Stage | Initial Release | Last Release | Maintenance Through | Extended Support |
|---|---|---|---|---|---|
| 8 | Active Development | Coming Soon | Coming Soon | Dec 2026 | **Coming Soon** (was: Available) |
| 7.2 | **Active Development** | Coming Soon | Coming Soon | Jun 2026 | **Coming Soon** (new row) |
| 7.1 | **Active Maintenance** (was: Active Development) | **Apr 2026** (was: Coming Soon) | **Ongoing** (was: Coming Soon) | Jun 2026 | Available |
| 7 | Active Maintenance | Oct 2025 | Ongoing | Jun 2026 | Available |
| 6 | End of Support | Jul 2023 | Jan 2025 (6.2.3) | Jun 2025 | **Available (6.2.x only)** |
| 5 | End of Support | Oct 2021 | Jan 2024 (5.3.6) | Jun 2024 | **Not Available** (was: Available) |
| 4 | End of Support | Jul 2019 | Jan 2024 (4.1.4) | Mar 2024 | **Not Available** (was: Available) |
| 3 | End of Support | Mar 2015 | Jan 2024 (3.3.18) | Sep 2021 | **Not Available** (was: Available) |
| 2 | End of Support | Dec 2011 | Mar 2017 (2.5.6) | Jun 2021 | **Not Available** (was: Available) |
| 1 | End of Support | Feb 2008 | May 2012 (1.3.9) | Not Available | Not Available |

## Commits

1. `be7d5ae` - Move OpenLogic from Extended Grails Support to Commercial Support
2. `68bcb1e` - Update support schedule for v7.1.0 release and extended support reality
3. `0ee3047` - fix: bump 'Last updated' dates for modified support sections (addresses Copilot review feedback)