### PR TITLE
Freeze auto-publish to grails-guides-template gh-pages (refs #354)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,11 +48,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GRAILS_GHTOKEN }}
           GH_BRANCH: asf-site-production
           GRADLE_TASK: build
-          GRAILS_WS_URL: https://grails.apache.org    
-      - name: Publish Guides Site
-        run: ./publish.sh
-        env:
-          GITHUB_SLUG: grails-guides/grails-guides-template
-          GH_BRANCH: gh-pages
-          GH_TOKEN: ${{ secrets.APACHE_GRAILS_BUILD_GH_TOKEN }}
-          GRADLE_TASK: buildGuide
+          GRAILS_WS_URL: https://grails.apache.org
+      # NOTE: The previous "Publish Guides Site" step that pushed to
+      # grails-guides/grails-guides-template gh-pages has been removed as part
+      # of the migration tracked in issue #354. The legacy guides site at
+      # https://guides.grails.org/ remains served from that gh-pages branch
+      # (now frozen) until the new canonical location at
+      # https://grails.apache.org/guides/ is fully cut over, at which point the
+      # main "Publish Main Site" step above will deploy guides as part of the
+      # unified site. See .sisyphus/plans/issue-354-publishing-migration-v7.md
+      # Phase 12 for the cutover details.


### PR DESCRIPTION
## Summary

Removes the "Publish Guides Site" step from `publish.yml`. That step pushed every cron run + push to `grails-guides/grails-guides-template` `gh-pages` (which serves https://guides.grails.org/).

This is **Phase 1a** of the migration tracked in #354. Phase 1 freezes the legacy guides site so the new canonical location at https://grails.apache.org/guides/ can be built and verified before any redirect cutover. After the migration completes, the main "Publish Main Site" step will deploy guides as part of the unified site (Phase 12).

## What this PR changes

- Removes the `Publish Guides Site` step (was 7 lines)
- Adds an inline comment block explaining the removal and pointing to the migration plan and Phase 12 (which re-enables guides publishing under the main site)
- Trims trailing whitespace on the preceding `GRAILS_WS_URL` line

## What this PR does NOT change

- The `Publish Main Site` step continues to deploy `apache/grails-website` `asf-site-production` on push, cron (every 2h), and `workflow_dispatch`. The main site at https://grails.apache.org/ is unaffected.
- The legacy `https://guides.grails.org/` content remains served from the existing `grails-guides-template` `gh-pages` branch (now frozen, no further automatic updates) until Phase 15 redirects it.

## Companion changes (next steps in Phase 1, after this PR merges)

1. **Phase 1b**: Direct commits to `grails-guides/grails-guides-template` `master` + `6.0.x` to neuter the curl'd `githubactions/build-guide` and `githubactions/republish-guides-website.sh` scripts. This stops the 94 individual guide repo CIs from auto-pushing to `gh-pages` even when someone makes a typo fix in any guide repo.
2. **Phase 1c**: Branch protection on `grails-guides-template gh-pages` with "Include administrators" checked.
3. **Phase 1d**: Capture `freeze-baseline.yml` snapshot (gh-pages SHA, recursive paths, guides.json SHA).
4. **Phase 1e**: 24-hour SHA stability soak.

## Migration plan

Full plan in this repo: `/plans/issue-354-publishing-migration-v7.md`. 15 phases, 7+ day production soak with both old and new sites alive before any irreversible cleanup.

## Verification

- `publish.yml` parses cleanly as YAML (validated locally)
- LSP diagnostics on `.github/workflows/publish.yml`: clean
- The remaining `Publish Main Site` step is unchanged
