### PR TITLE
Resolve buildGuide/buildGuides task name ambiguity (refs #354)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ You can get more info by running:
 
  Grails tasks
  ------------
+ buildGuide - Alias for buildGuides (kept for backward compatibility)
  buildGuides - Build guides website - generates guides pages, copies assets and generates a sitemap
  copyAssets - Copies css, js, fonts and images from the assets folder to the dist folder
  genDocs - Generates documentation HTML page - build/temp/documentation.html

--- a/buildSrc/src/main/groovy/website/gradle/GrailsWebsitePlugin.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/GrailsWebsitePlugin.groovy
@@ -75,9 +75,7 @@ class GrailsWebsitePlugin implements Plugin<Project> {
 
         RenderSiteTask.register(project, siteExt).configure {
 
-            // The Grails Guides are not part of this site, they are published to https://guides.grails.org
-            // and hosted at gh-pages in https://github.com/grails/grails-guides-template
-            // The buildGuides task can be used to generate the guide site.
+            // The buildGuides task generates the guides site separately.
 
             it.dependsOn(AssetsTask.NAME)
             it.dependsOn(DocumentationTask.NAME)
@@ -94,14 +92,18 @@ class GrailsWebsitePlugin implements Plugin<Project> {
         }
 
         project.tasks.register('buildGuides') {
-            // Task for only generating the Grails Guides which are published to https://guides.grails.org
-            // and hosted at gh-pages in https://github.com/grails/grails-guides-template
             it.description = 'Build guides website - generates guides pages, copies assets and generates a sitemap'
             it.group = GrailsWebsiteTask.GROUP
             it.dependsOn(AssetsTask.NAME)
             it.dependsOn(GuidesTask.NAME)
             it.finalizedBy(SitemapTask.NAME)
+        }
 
+        // Backward-compatible alias for the historically-documented singular name.
+        project.tasks.register('buildGuide') {
+            it.description = 'Alias for buildGuides (kept for backward compatibility)'
+            it.group = GrailsWebsiteTask.GROUP
+            it.dependsOn('buildGuides')
         }
 
         project.tasks.named('build') {


### PR DESCRIPTION
## Summary

Resolve a long-standing task-name ambiguity that has lived between this project's README and its Gradle plugin:

* The README documents `./gradlew buildGuide` (singular).
* `GrailsWebsitePlugin` only registered `buildGuides` (plural).

Anyone copy-pasting from the README would hit `task not found`. This PR fixes that without breaking either form.

## Changes

* Register a `buildGuide` (singular) Gradle task that `dependsOn 'buildGuides'`. The plural form remains canonical; the singular is a pure alias kept for backward compatibility with the README and any external snippets.
* List both names in the README task table.
* Drop a stale comment in `GrailsWebsitePlugin.groovy` that said "Guides are not part of this site, they are published to https://guides.grails.org" -- this is no longer accurate as the guides migration moves docs into this build.

## Verification

* `./gradlew tasks --all` -> shows both:
  * `buildGuide  - Alias for buildGuides (kept for backward compatibility)`
  * `buildGuides - Build guides website - generates guides pages, copies assets and generates a sitemap`
* `./gradlew clean build` -> BUILD SUCCESSFUL (exit 0).

Refs #354 (Phase 3 of the publishing migration).