### PR TITLE
Fix publish.sh mirror semantics + add publish.yml concurrency (refs #354)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,11 @@ on:
   schedule:
     - cron:  '0 */2 * * *'
   workflow_dispatch:
+# Prevent two simultaneous publishes from racing on the deploy branch.
+# cancel-in-progress=false so the in-flight deploy completes before the next.
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   build:
     permissions:

--- a/publish.sh
+++ b/publish.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+# Fail fast if required token is missing.
 if [ -z "$GH_TOKEN" ]
 then
   echo "You must provide the action with a GitHub Personal Access Token secret in order to deploy."
@@ -20,6 +21,10 @@ fi
 git config --global user.name "$GITHUB_ACTOR"
 git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+# Run the Gradle build. The `|| EXIT_STATUS=$?` intentionally suppresses
+# `set -e` so a clear failure message can be printed; the exit is re-raised
+# below.
+EXIT_STATUS=0
 ./gradlew clean ${GRADLE_TASK} || EXIT_STATUS=$?
 
 if [[ $EXIT_STATUS -ne 0 ]]; then
@@ -29,16 +34,25 @@ fi
 
 git clone https://${GH_TOKEN}@github.com/${GITHUB_SLUG}.git -b ${GH_BRANCH} ${GH_BRANCH} --single-branch --depth 1 > /dev/null
 cd ${GH_BRANCH}
-cp -rv ../build/dist/. .
-if git diff --quiet; then
+
+# Mirror sync the build output into the deploy branch. Using rsync rather
+# than cp -r so files removed from build/dist/ also get removed from the
+# deploy branch (the previous cp -r approach accumulated stale files
+# forever). --exclude='.git' preserves the deploy branch's git metadata.
+rsync -a --delete --exclude='.git' ../build/dist/ ./
+
+git add -A
+# Use git status --porcelain to detect ANY change (tracked or untracked).
+# The previous `git diff --quiet` missed pure-addition cases because it
+# only inspected tracked files.
+if [ -z "$(git status --porcelain)" ]; then
   echo "No changes in MAIN Website"
 else
-  git add -A
-  git commit -a -m "Updating $GITHUB_SLUG ${GH_BRANCH} branch for Github Actions run:$GITHUB_RUN_ID"
+  git commit -m "Updating $GITHUB_SLUG ${GH_BRANCH} branch for GitHub Actions run:$GITHUB_RUN_ID"
   git push https://oauth2:${GH_TOKEN}@github.com/${GITHUB_SLUG}.git ${GH_BRANCH}
 fi
 
 cd ..
 rm -rf ${GH_BRANCH}
 
-exit $EXIT_STATUS
+exit 0


### PR DESCRIPTION
## Summary

Two long-standing bugs in `publish.sh` plus a defensive concurrency guard on `publish.yml`.

### `publish.sh` mirror semantics

Replace `cp -rv ../build/dist/. .` + `git diff --quiet` with `rsync -a --delete --exclude=".git"` + `git status --porcelain`.

* `cp -rv` accumulated stale files in the deploy branch forever -- nothing ever removed paths that disappeared from the source build, so the deploy branch grew indefinitely with leftover content from past builds.
* `git diff --quiet` only inspected TRACKED files. When the build emitted ONLY new (untracked) files the script printed "No changes" and skipped the commit even though there were genuinely new pages to deploy.

`rsync -a --delete` brings the deploy branch into byte-for-byte alignment with `build/dist/` while preserving the deploy branch's git metadata via `--exclude=".git"`. `rsync` is universally available on Ubuntu CI runners.

`git status --porcelain` reports BOTH tracked and untracked changes, so pure-addition cases are now detected.

### Concurrency group on `publish.yml`

Two simultaneous publishes (e.g. a manual `workflow_dispatch` landing on top of a cron run) would race against the deploy branch and could produce non-deterministic results.

```yaml
concurrency:
  group: publish-${{ github.ref }}
  cancel-in-progress: false
```

`cancel-in-progress: false` because letting an in-flight deploy finish is preferable to interrupting it; the next event queues and runs.

Refs #354 (operational hardening for the publishing migration).