### PR TITLE
Add buildSrc deps for guides build + scripts/ directory (refs #354)

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,6 +9,16 @@ ext {
 
 repositories {
     mavenCentral()
+    // Grails Foundation artifacts (e.g. grails-docs) are not on Maven Central.
+    // Restrict to the grails groups so this repo cannot accidentally serve
+    // unrelated artifacts (supply-chain hardening).
+    maven {
+        url = 'https://repo.grails.org/grails/core'
+        content {
+            includeGroup 'org.grails'
+            includeGroup 'org.grails.plugins'
+        }
+    }
 }
 
 dependencies {
@@ -20,7 +30,17 @@ dependencies {
     implementation 'io.micronaut.rss:micronaut-rss-core'
     implementation 'io.micronaut.validation:micronaut-validation'
     implementation 'jakarta.annotation:jakarta.annotation-api'
-    implementation 'org.yaml:snakeyaml'
+
+    // Explicit pin >= 2.0 mitigates CVE-2022-1471. Was previously transitive
+    // unversioned via the Micronaut platform BOM.
+    implementation 'org.yaml:snakeyaml:2.3'
+
+    // AsciiDoc parser used by the guides build (custom include resolver,
+    // include:: vendoring helpers).
+    implementation 'org.asciidoctor:asciidoctorj:2.5.13'
+
+    // HTML parser used by the guides verification harness.
+    implementation 'org.jsoup:jsoup:1.18.1'
 
     testImplementation 'org.spockframework:spock-core'
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,40 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# scripts/
+
+Operational scripts. Each script documents its own arguments and
+preconditions in a header comment.
+
+## Tooling prerequisites
+
+Local development assumes the following are on `PATH`:
+
+| Tool | Purpose |
+|---|---|
+| `gh` (GitHub CLI), authenticated | API calls, PR creation, branch settings |
+| `yq` (Mike Farah Go version) | YAML parsing in shell scripts |
+| JDK 17+ | Gradle build (JDK 18+ also enables `jwebserver` for local preview, JEP 408) |
+| `rsync` (Ubuntu CI default; `brew install rsync` on macOS) | `publish.sh` deploy step |
+| `git` | repo operations |
+
+## Running a script
+
+Scripts are POSIX shell unless otherwise noted:
+
+```bash
+./scripts/<name>.sh [args]
+```


### PR DESCRIPTION
## Summary

Wire up the build-time dependencies the guides build will need, plus a `scripts/` home for operational scripts.

### `buildSrc/build.gradle`

* Add the Grails Foundation maven repo (`https://repo.grails.org/grails/core`). Grails Foundation artifacts (e.g. `grails-docs`) are not on Maven Central.
* Add `org.asciidoctor:asciidoctorj:2.5.13` -- AsciiDoc parser used by the guides build for the custom include resolver.
* Add `org.jsoup:jsoup:1.18.1` -- HTML parser used by the guides verification harness.
* Pin `org.yaml:snakeyaml:2.3` explicitly. Was previously transitive-unversioned via the Micronaut platform BOM. The explicit pin (>= 2.0) mitigates CVE-2022-1471.

### `scripts/`

New directory with `.gitkeep` and a short `README.md` documenting tooling prerequisites (`gh`, `yq`, JDK 17+, `rsync`, `git`) and the standard script invocation pattern. Future operational scripts land here.

## Verification

* `./gradlew -p buildSrc test` -> BUILD SUCCESSFUL (exit 0).
* `./gradlew clean build` -> BUILD SUCCESSFUL (exit 0).
* Resolved versions in `:buildSrc:runtimeClasspath` (all >= explicit pins; no CVE-2022-1471 SnakeYAML present):
  * `org.yaml:snakeyaml:2.3 -> 2.4` (BOM transitive upgrade)
  * `org.asciidoctor:asciidoctorj:2.5.13 -> 3.0.0` (BOM transitive upgrade)
  * `org.jsoup:jsoup:1.18.1 -> 1.21.2` (BOM transitive upgrade)

Refs #354.