### PR TITLE
Add grails-docs:6.2.0 with Codehaus Groovy excluded (refs #354)

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,14 +9,20 @@ ext {
 
 repositories {
     mavenCentral()
-    // Grails Foundation artifacts (e.g. grails-docs) are not on Maven Central.
-    // Restrict to the grails groups so this repo cannot accidentally serve
-    // unrelated artifacts (supply-chain hardening).
+    // Grails Foundation artifacts and transitive deps that are mirrored only
+    // through the grails repo (e.g. xhtmlrenderer used by grails-docs PDF
+    // rendering). Scoped tightly so this repo cannot accidentally serve
+    // unrelated artifacts.
     maven {
         url = 'https://repo.grails.org/grails/core'
         content {
             includeGroup 'org.grails'
             includeGroup 'org.grails.plugins'
+            // Specific transitive: xhtmlrenderer's `core-renderer` artifact
+            // is required by grails-docs PDF output and is not on Maven
+            // Central. Allowlist just that module rather than the whole
+            // group.
+            includeModule 'org.xhtmlrenderer', 'core-renderer'
         }
     }
 }
@@ -41,6 +47,17 @@ dependencies {
 
     // HTML parser used by the guides verification harness.
     implementation 'org.jsoup:jsoup:1.18.1'
+
+    // Grails Foundation's docs renderer. The 6.2.0 release brings
+    // `org.codehaus.groovy:groovy:3.0.21` transitively; this buildSrc runs
+    // on the Apache Groovy 4.x that Gradle 9 ships embedded with the
+    // `groovy-gradle-plugin`. Excluding the codehaus Groovy at the
+    // dependency level lets the embedded Apache Groovy 4 satisfy
+    // grails-docs at runtime; their public APIs are compatible enough for
+    // grails-docs's usage.
+    implementation('org.grails:grails-docs:6.2.0') {
+        exclude group: 'org.codehaus.groovy'
+    }
 
     testImplementation 'org.spockframework:spock-core'
 


### PR DESCRIPTION
## Summary

Adds the deferred `org.grails:grails-docs:6.2.0` dependency that the guides build needs for the `PublishGuide` AsciiDoctor renderer task.

The dependency was deferred from a previous toolchain-bootstrap change because it transitively brings `org.codehaus.groovy:groovy:3.0.21`, which conflicts with the Apache Groovy 4.x classpath this `buildSrc` already runs on (via Spock 4.0+).

## Why exclude rather than substitute?

Two reasonable resolutions to the Groovy 3 vs 4 conflict:

| Strategy | Pros | Cons |
|---|---|---|
| (a) Capability resolution: substitute every `org.codehaus.groovy:*` with the matching `org.apache.groovy:*` | Forces a single Groovy 4 across the classpath | Brittle against Groovy submodule renames; needs a per-submodule list or runtime substitution rule |
| (b) Exclude `org.codehaus.groovy` from `grails-docs` entirely | Apache Groovy already on classpath satisfies grails-docs at runtime; no per-module list to maintain | Relies on Apache Groovy 4 being API-compatible with Codehaus Groovy 3 for grails-docs's usage |

Going with (b). The public APIs of Apache Groovy 4.x are compatible enough with Codehaus Groovy 3.x for `grails-docs`'s actual usage (plain Groovy script execution + a small surface of utility classes), and (b) is more robust against future Groovy submodule renames.

## Follow-up dependency

`org.xhtmlrenderer:core-renderer:8.0` (used by grails-docs for PDF rendering) is mirrored only through `repo.grails.org`, not Maven Central. Its group is added to the existing scoped `content { }` block on that repo so the supply-chain hardening from the previous change still applies.

## Resolved versions on `:buildSrc:runtimeClasspath`

```
org.grails:grails-docs:6.2.0
+-- org.asciidoctor:asciidoctorj:2.5.12 -> 3.0.0  (BOM upgrade)
\-- org.xhtmlrenderer:core-renderer:8.0

org.codehaus.groovy:*                  excluded
org.apache.groovy:groovy:4.0.x         already present, satisfies grails-docs
```

## Verification

* `./gradlew -p buildSrc test` -> BUILD SUCCESSFUL. All existing tests pass; no regressions from the Codehaus Groovy exclusion.
* `./gradlew clean build` -> BUILD SUCCESSFUL.
* `./gradlew -p buildSrc dependencies --configuration runtimeClasspath` -> shows `grails-docs:6.2.0` on classpath with the expected resolved transitives.

## What this unblocks

The next change can register `PublishGuide` tasks against the migrated fixture without further dependency work.

Refs #354.