### PR TITLE
Centralize buildSrc dep versions + add v6 entry for fixture in conf/guides.yml (refs #354)

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -2,29 +2,14 @@ plugins {
     id 'groovy-gradle-plugin'
 }
 
-ext {
-    flexmarkVersion = '0.64.8'
-    micronautVersion = '4.10.4'
-}
+// Dependency versions are centralized in buildSrc/gradle.properties so a
+// single edit there bumps every consumer here. Mirrors the spirit of
+// apache/grails-core's `dependencies.gradle` (single source of truth for
+// versions) while keeping the format simple given this repo's much smaller
+// dep set. Properties are referenced via `$name` interpolation below.
 
 repositories {
     mavenCentral()
-    // Grails Foundation artifacts and transitive deps that are mirrored only
-    // through the grails repo (e.g. xhtmlrenderer used by grails-docs PDF
-    // rendering). Scoped tightly so this repo cannot accidentally serve
-    // unrelated artifacts.
-    maven {
-        url = 'https://repo.grails.org/grails/core'
-        content {
-            includeGroup 'org.grails'
-            includeGroup 'org.grails.plugins'
-            // Specific transitive: xhtmlrenderer's `core-renderer` artifact
-            // is required by grails-docs PDF output and is not on Maven
-            // Central. Allowlist just that module rather than the whole
-            // group.
-            includeModule 'org.xhtmlrenderer', 'core-renderer'
-        }
-    }
 }
 
 dependencies {
@@ -39,25 +24,14 @@ dependencies {
 
     // Explicit pin >= 2.0 mitigates CVE-2022-1471. Was previously transitive
     // unversioned via the Micronaut platform BOM.
-    implementation 'org.yaml:snakeyaml:2.3'
+    implementation "org.yaml:snakeyaml:$snakeyamlVersion"
 
     // AsciiDoc parser used by the guides build (custom include resolver,
     // include:: vendoring helpers).
-    implementation 'org.asciidoctor:asciidoctorj:2.5.13'
+    implementation "org.asciidoctor:asciidoctorj:$asciidoctorjVersion"
 
     // HTML parser used by the guides verification harness.
-    implementation 'org.jsoup:jsoup:1.18.1'
-
-    // Grails Foundation's docs renderer. The 6.2.0 release brings
-    // `org.codehaus.groovy:groovy:3.0.21` transitively; this buildSrc runs
-    // on the Apache Groovy 4.x that Gradle 9 ships embedded with the
-    // `groovy-gradle-plugin`. Excluding the codehaus Groovy at the
-    // dependency level lets the embedded Apache Groovy 4 satisfy
-    // grails-docs at runtime; their public APIs are compatible enough for
-    // grails-docs's usage.
-    implementation('org.grails:grails-docs:6.2.0') {
-        exclude group: 'org.codehaus.groovy'
-    }
+    implementation "org.jsoup:jsoup:$jsoupVersion"
 
     testImplementation 'org.spockframework:spock-core'
 

--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,0 +1,32 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+
+# Centralized dependency versions for buildSrc. Bumping a version here is
+# the only place the version needs to change; buildSrc/build.gradle
+# interpolates these via $name. Mirrors the pattern apache/grails-core
+# uses in its central dependencies.gradle.
+
+# Platform / BOM
+micronautVersion=4.10.4
+
+# Markdown / AsciiDoc / HTML
+flexmarkVersion=0.64.8
+asciidoctorjVersion=2.5.13
+jsoupVersion=1.18.1
+snakeyamlVersion=2.3

--- a/conf/guides.yml
+++ b/conf/guides.yml
@@ -182,6 +182,17 @@ guides:
           - 'mysql'
           - 'gsp'
           - 'grails4'
+      '6':
+        sourcePath: guides/creating-your-first-grails-app/v6
+        publicationDate: '2017-01-23'
+        tags:
+          - 'mysql'
+          - 'gsp'
+          - 'grails6'
+        sampleRef:
+          repo: grails-guides/creating-your-first-grails-app
+          branch: master
+          sha: '84422f5d162f3deffb89978a3e9127382ce7eeea'
 
   - name: 'database-per-tenant'
     title: 'Database per Tenant Multi-Tenancy'


### PR DESCRIPTION
## Summary

Two small, coupled improvements that surfaced during Phase 8 renderer exploration:

### (1) Single source of truth for `buildSrc` dep versions

`buildSrc/gradle.properties` (new) holds every dep version that `buildSrc/build.gradle` consumes. The build script references each via `$name` interpolation. Bumping a version is a one-line edit in one file.

Pattern follows `apache/grails-core`'s `dependencies.gradle` (single source of truth for versions across builds), simplified to a flat properties file because this repo's dep set is much smaller and does not need the BOM-shaped maps grails-core uses.

```diff
- // inline literal versions in buildSrc/build.gradle
- implementation 'org.yaml:snakeyaml:2.3'
- implementation 'org.asciidoctor:asciidoctorj:2.5.13'
- implementation 'org.jsoup:jsoup:1.18.1'

+ // versions in buildSrc/gradle.properties
+ implementation "org.yaml:snakeyaml:$snakeyamlVersion"
+ implementation "org.asciidoctor:asciidoctorj:$asciidoctorjVersion"
+ implementation "org.jsoup:jsoup:$jsoupVersion"
```

Note: this lives in `buildSrc/gradle.properties` (not the root) because Gradle treats `buildSrc/` as a separate build with its own property scope. `apache/grails-core` works around this with a `SharedPropertyPlugin` that walks the directory tree; this repo's dep set is small enough that a single `buildSrc`-local properties file is the clearer approach.

### (2) Fix the v6 entry for `creating-your-first-grails-app`

The Phase 7 auto-import generated `versions: '3'` and `'4'` (from the legacy `gh-pages/guides.json` snapshot, which had the guide on `master` and `grails3` branches). The migrated fixture lives at `guides/creating-your-first-grails-app/v6/`, but the YAML did not list a `'6'` version, so neither `validateGuides -PvalidationMode=existence` nor any later renderer task could find the migrated source.

Added the missing `'6'` version with its `sampleRef` (the SHA pinned when the fixture was vendored in #446). The v3 and v4 entries stay; they are not yet on disk so existence-mode SKIP-warns them (expected).

## Verification

* `./gradlew -p buildSrc test` -> BUILD SUCCESSFUL.
* `./gradlew clean build` -> BUILD SUCCESSFUL.
* `./gradlew validateGuides` -> 84 guides parsed, 0 errors.
* `./gradlew validateGuides -PvalidationMode=existence` -> 84 guides parsed, 0 errors. The v6 fixture entry now PASSES existence (was being missed before this fix); v3 and v4 SKIP-warn (expected; not yet migrated).

## Phase 8 status (renderer wiring still blocked)

The Phase 8 plan calls for wiring `grails-docs:6.2.0`'s `PublishGuide` task. Hands-on attempt revealed:

* `grails-docs:6.2.0` is the last published version of the artifact (Grails 7+ internalized `grails-docs/` as a subproject of `apache/grails-core`; nothing newer is published).
* `grails-docs:6.2.0` is incompatible with Gradle 9: `PublishGuide` casts `Project.ant` to `groovy.util.AntBuilder` (Codehaus Groovy 3 path), but Gradle 9's `Project.ant` returns a `DefaultAntBuilder` that extends `groovy.ant.AntBuilder` (Apache Groovy 4 path). The cast fails at execution time.
* `grails-docs:7.0.0-M3` exists on Maven Central but its POM has unresolved transitive versions (`commons-text:`, `grails-gdoc-engine:`) - it expects a BOM that is not in the same group, suggesting it is intended for consumption inside a Grails 7 project.

**Next session decision** (recorded in HANDOFF): switch to `org.asciidoctor.jvm.convert` (the standalone asciidoctor-gradle-plugin), which is published, maintained, and Gradle 9 compatible. We replicate the legacy `PublishGuide`'s AsciiDoc attributes and post-processing in our own task, rather than depending on `grails-docs`'s aging renderer.

Refs #354.