### PR TITLE
Verification harness for rendered guides (refs #354)

### DIFF
--- a/buildSrc/src/main/groovy/website/gradle/GrailsWebsitePlugin.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/GrailsWebsitePlugin.groovy
@@ -24,8 +24,11 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 import website.gradle.tasks.AssetsTask
+import website.gradle.tasks.AcceptanceReportTask
+import website.gradle.tasks.AsciidoctorWarningGateTask
 import website.gradle.tasks.BlogTask
 import website.gradle.tasks.BskyAtProtoDidTask
+import website.gradle.tasks.CrawlBuiltGuidesTask
 import website.gradle.tasks.CspScanTask
 import website.gradle.tasks.DocumentationTask
 import website.gradle.tasks.DownloadTask
@@ -39,6 +42,7 @@ import website.gradle.tasks.PublishMainSiteTask
 import website.gradle.tasks.QuestionsTask
 import website.gradle.tasks.RenderSiteTask
 import website.gradle.tasks.SitemapTask
+import website.gradle.tasks.StructuralDiffGuidesTask
 import website.gradle.tasks.ValidateGuidesTask
 
 @CompileStatic
@@ -131,5 +135,22 @@ class GrailsWebsitePlugin implements Plugin<Project> {
         // Scans build/dist/ HTML for non-allowlisted https:// references.
         // Allowlist: conf/csp-allowlist.yml. Report: build/reports/csp-scan.md.
         CspScanTask.register(project)
+
+        AsciidoctorWarningGateTask.register(project)
+        CrawlBuiltGuidesTask.register(project)
+        StructuralDiffGuidesTask.register(project)
+        AcceptanceReportTask.register(project)
+
+        project.tasks.register('verifyAllGuides') {
+            it.group = 'migration'
+            it.description = 'Runs the rendered-guide verification harness in report-only mode by default. Use -PverificationMode=hard-fail to fail on violations.'
+            it.notCompatibleWithConfigurationCache('Guide verification runs vendored PublishGuide tasks with log capture and aggregate reports.')
+            it.dependsOn('buildAllGuides')
+            it.dependsOn(AsciidoctorWarningGateTask.NAME)
+            it.dependsOn(CrawlBuiltGuidesTask.NAME)
+            it.dependsOn(StructuralDiffGuidesTask.NAME)
+            it.dependsOn(CspScanTask.NAME)
+            it.dependsOn(AcceptanceReportTask.NAME)
+        }
     }
 }

--- a/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
@@ -269,6 +269,9 @@ class RenderGuidesPlugin {
         project.tasks.register(aggregateName) { task ->
             task.group = taskGroup
             task.description = description
+            if (aggregateName == AGGREGATE_TASK) {
+                task.notCompatibleWithConfigurationCache('Runs vendored PublishGuide tasks and their log-capture finalizers.')
+            }
             for (String name : taskNames) {
                 task.dependsOn(name)
             }

--- a/buildSrc/src/main/groovy/website/gradle/tasks/AcceptanceReportTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/AcceptanceReportTask.groovy
@@ -1,0 +1,389 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package website.gradle.tasks
+
+import groovy.transform.CompileStatic
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
+
+/**
+ * Aggregates per-guide verification gate outputs into build/reports/acceptance.csv.
+ */
+@CompileStatic
+class AcceptanceReportTask extends DefaultTask {
+
+    static final String NAME = 'acceptanceReport'
+    static final String GROUP = 'migration'
+
+    @Optional
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
+    final DirectoryProperty guidesDir = project.objects.directoryProperty()
+
+    @Optional
+    @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
+    final RegularFileProperty asciidoctorReportFile = project.objects.fileProperty()
+
+    @Optional
+    @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
+    final RegularFileProperty crawlReportFile = project.objects.fileProperty()
+
+    @Optional
+    @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
+    final RegularFileProperty structuralReportFile = project.objects.fileProperty()
+
+    @Optional
+    @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
+    final RegularFileProperty cspReportFile = project.objects.fileProperty()
+
+    @OutputFile
+    final RegularFileProperty reportFile = project.objects.fileProperty()
+
+    @Input
+    final Property<Boolean> failOnViolation = project.objects.property(Boolean)
+
+    @TaskAction
+    void report() {
+        File guidesRoot = guidesDir.get().asFile
+        Map<String, GateResult> asciidoctorResults = parseCsvReport(optionalFile(asciidoctorReportFile))
+        Map<String, GateResult> crawlResults = parseCsvReport(optionalFile(crawlReportFile))
+        Map<String, GateResult> structuralResults = parseCsvReport(optionalFile(structuralReportFile))
+        CspAggregation cspAggregation = parseCspReport(optionalFile(cspReportFile))
+
+        Set<String> guideKeys = [] as LinkedHashSet<String>
+        guideKeys.addAll(discoverGuideKeys(guidesRoot))
+        guideKeys.addAll(asciidoctorResults.keySet())
+        guideKeys.addAll(crawlResults.keySet())
+        guideKeys.addAll(structuralResults.keySet())
+        guideKeys.addAll(cspAggregation.issuesByGuide.keySet())
+
+        if (guideKeys.isEmpty()) {
+            writeCsv(reportFile.get().asFile, [])
+            return
+        }
+
+        List<AcceptanceRow> rows = []
+        for (String key : guideKeys.toList().sort()) {
+            Pair pair = splitKey(key)
+            GateResult asciidoctor = asciidoctorResults[key] ?: GateResult.review('asciidoctorWarningGate report row missing.')
+            GateResult crawl = crawlResults[key] ?: GateResult.review('crawlBuiltGuides report row missing.')
+            GateResult structural = structuralResults[key] ?: GateResult.review('structuralDiffGuides report row missing.')
+            GateResult csp = cspResultFor(key, cspAggregation)
+            String verdict = mergeVerdict([asciidoctor.status, crawl.status, structural.status, csp.status])
+            String details = summarizeDetails(asciidoctor, crawl, structural, csp)
+            rows << new AcceptanceRow(
+                    guide: pair.guide,
+                    version: pair.version,
+                    asciidoctorWarningGate: asciidoctor.status,
+                    crawlBuiltGuides: crawl.status,
+                    structuralDiffGuides: structural.status,
+                    cspScan: csp.status,
+                    verdict: verdict,
+                    details: details,
+            )
+        }
+
+        File outputFile = reportFile.get().asFile
+        writeCsv(outputFile, rows)
+
+        boolean hasFailed = rows.any { AcceptanceRow row -> row.verdict == 'FAILED' }
+        if (hasFailed && failOnViolation.get()) {
+            throw new GradleException("Acceptance report contains FAILED rows. See ${outputFile.absolutePath}.")
+        }
+    }
+
+    static TaskProvider<AcceptanceReportTask> register(Project project) {
+        project.tasks.register(NAME, AcceptanceReportTask) { AcceptanceReportTask task ->
+            task.group = GROUP
+            task.description = 'Aggregates guide verification outputs into build/reports/acceptance.csv.'
+            task.guidesDir.convention(project.layout.buildDirectory.dir('dist/guides'))
+            task.asciidoctorReportFile.convention(project.layout.buildDirectory.file('reports/asciidoctor-warning-gate.csv'))
+            task.crawlReportFile.convention(project.layout.buildDirectory.file('reports/crawl-built-guides.csv'))
+            task.structuralReportFile.convention(project.layout.buildDirectory.file('reports/structural-diff-guides.csv'))
+            task.cspReportFile.convention(project.layout.buildDirectory.file('reports/csp-scan.md'))
+            task.reportFile.convention(project.layout.buildDirectory.file('reports/acceptance.csv'))
+            task.failOnViolation.convention(isHardFailMode(project))
+            task.dependsOn(AsciidoctorWarningGateTask.NAME)
+            task.dependsOn(CrawlBuiltGuidesTask.NAME)
+            task.dependsOn(StructuralDiffGuidesTask.NAME)
+            task.dependsOn(CspScanTask.NAME)
+        }
+    }
+
+    private static Set<String> discoverGuideKeys(File guidesRoot) {
+        Set<String> keys = [] as LinkedHashSet<String>
+        if (!guidesRoot.isDirectory()) {
+            return keys
+        }
+        File[] guideDirs = guidesRoot.listFiles()
+        if (guideDirs == null) {
+            return keys
+        }
+        for (File guideDir : guideDirs) {
+            if (!guideDir.isDirectory()) {
+                continue
+            }
+            File[] versionDirs = guideDir.listFiles()
+            if (versionDirs == null) {
+                continue
+            }
+            for (File versionDir : versionDirs) {
+                if (versionDir.isDirectory()) {
+                    keys << keyFor(guideDir.name, versionDir.name)
+                }
+            }
+        }
+        keys
+    }
+
+    private static Map<String, GateResult> parseCsvReport(File csvFile) {
+        Map<String, GateResult> results = [:]
+        if (csvFile == null || !csvFile.isFile()) {
+            return results
+        }
+        List<String> lines = csvFile.readLines('UTF-8')
+        for (int index = 1; index < lines.size(); index++) {
+            String line = lines[index]
+            if (line.trim().isEmpty()) {
+                continue
+            }
+            List<String> parts = splitCsv(line)
+            if (parts.size() < 5) {
+                continue
+            }
+            String key = keyFor(parts[0], parts[1])
+            results[key] = new GateResult(
+                    status: parts[2],
+                    details: parts[4],
+            )
+        }
+        results
+    }
+
+    private static CspAggregation parseCspReport(File reportFile) {
+        CspAggregation aggregation = new CspAggregation(clean: true)
+        if (reportFile == null || !reportFile.isFile()) {
+            aggregation.clean = false
+            aggregation.generalMessage = 'cspScan report is missing.'
+            return aggregation
+        }
+        reportFile.eachLine('UTF-8') { String line ->
+            String trimmed = line.trim()
+            if (trimmed.startsWith('- `guides/')) {
+                String path = trimmed.substring(3, trimmed.length() - 1)
+                List<String> segments = path.replace('\\', '/').tokenize('/')
+                if (segments.size() >= 4) {
+                    String key = keyFor(segments[1], segments[2])
+                    aggregation.issuesByGuide.computeIfAbsent(key) { [] }.add(path)
+                    aggregation.clean = false
+                }
+            } else if (trimmed.startsWith('- `guides\\')) {
+                String path = trimmed.substring(3, trimmed.length() - 1)
+                List<String> segments = path.replace('\\', '/').tokenize('/')
+                if (segments.size() >= 4) {
+                    String key = keyFor(segments[1], segments[2])
+                    aggregation.issuesByGuide.computeIfAbsent(key) { [] }.add(path)
+                    aggregation.clean = false
+                }
+            }
+            if (trimmed.startsWith('Non-allowlisted hosts found:')) {
+                String count = trimmed.substring(trimmed.lastIndexOf(':') + 1).trim()
+                if (count != '0') {
+                    aggregation.clean = false
+                }
+            }
+            if (trimmed.contains('Result: CLEAN')) {
+                aggregation.clean = true
+            }
+        }
+        aggregation
+    }
+
+    private GateResult cspResultFor(String key, CspAggregation aggregation) {
+        if (!aggregation.issuesByGuide.containsKey(key)) {
+            if (aggregation.clean) {
+                return GateResult.verified('No non-allowlisted external hosts detected for this guide version.')
+            }
+            if (aggregation.generalMessage != null) {
+                return GateResult.review(aggregation.generalMessage)
+            }
+            return GateResult.verified('No non-allowlisted external hosts detected for this guide version.')
+        }
+        String details = abbreviate(aggregation.issuesByGuide[key].join(' | '))
+        return failOnViolation.get()
+                ? GateResult.failed(details)
+                : GateResult.review(details)
+    }
+
+    private static List<String> splitCsv(String line) {
+        List<String> parts = []
+        StringBuilder current = new StringBuilder()
+        int commasSeen = 0
+        for (int index = 0; index < line.length(); index++) {
+            char ch = line.charAt(index)
+            if (ch == ',' && commasSeen < 4) {
+                parts << current.toString()
+                current.setLength(0)
+                commasSeen++
+            } else {
+                current.append(ch)
+            }
+        }
+        parts << current.toString()
+        parts
+    }
+
+    private static String mergeVerdict(List<String> statuses) {
+        if (statuses.contains('FAILED')) {
+            return 'FAILED'
+        }
+        if (statuses.contains('REVIEW')) {
+            return 'REVIEW'
+        }
+        'VERIFIED'
+    }
+
+    private static String summarizeDetails(GateResult asciidoctor, GateResult crawl,
+            GateResult structural, GateResult csp) {
+        List<String> details = []
+        addDetail(details, 'asciidoctorWarningGate', asciidoctor)
+        addDetail(details, 'crawlBuiltGuides', crawl)
+        addDetail(details, 'structuralDiffGuides', structural)
+        addDetail(details, 'cspScan', csp)
+        if (details.isEmpty()) {
+            return 'All guide verification gates passed.'
+        }
+        abbreviate(details.join(' | '))
+    }
+
+    private static void addDetail(List<String> details, String gate, GateResult result) {
+        if (result.status != 'VERIFIED' && result.details != null && !result.details.isEmpty()) {
+            details.add("${gate}: ${result.details}".toString())
+        }
+    }
+
+    private static void writeCsv(File outputFile, List<AcceptanceRow> rows) {
+        outputFile.parentFile.mkdirs()
+        StringBuilder sb = new StringBuilder('guide,version,asciidoctorWarningGate,crawlBuiltGuides,structuralDiffGuides,cspScan,verdict,details\n')
+        for (AcceptanceRow row : rows) {
+            sb << sanitize(row.guide) << ','
+            sb << sanitize(row.version) << ','
+            sb << sanitize(row.asciidoctorWarningGate) << ','
+            sb << sanitize(row.crawlBuiltGuides) << ','
+            sb << sanitize(row.structuralDiffGuides) << ','
+            sb << sanitize(row.cspScan) << ','
+            sb << sanitize(row.verdict) << ','
+            sb << sanitize(row.details) << '\n'
+        }
+        outputFile.text = sb.toString()
+    }
+
+    private static File optionalFile(RegularFileProperty property) {
+        property.isPresent() ? property.get().asFile : null
+    }
+
+    private static boolean isHardFailMode(Project project) {
+        String mode = (project.findProperty('verificationMode') ?: '') as String
+        mode.equalsIgnoreCase('hard-fail')
+    }
+
+    private static String keyFor(String guide, String version) {
+        guide + '|' + version
+    }
+
+    private static Pair splitKey(String key) {
+        int separator = key.indexOf('|')
+        new Pair(
+                guide: separator >= 0 ? key.substring(0, separator) : key,
+                version: separator >= 0 ? key.substring(separator + 1) : '',
+        )
+    }
+
+    private static String abbreviate(String value) {
+        if (value.size() <= 1200) {
+            return value
+        }
+        value.substring(0, 1197) + '...'
+    }
+
+    private static String sanitize(String value) {
+        (value ?: '')
+                .replace('\r', ' ')
+                .replace('\n', ' ')
+                .replace(',', ';')
+                .trim()
+    }
+
+    private static final class Pair {
+        String guide
+        String version
+    }
+
+    private static final class GateResult {
+        String status
+        String details
+
+        static GateResult verified(String details) {
+            new GateResult(status: 'VERIFIED', details: details)
+        }
+
+        static GateResult review(String details) {
+            new GateResult(status: 'REVIEW', details: details)
+        }
+
+        static GateResult failed(String details) {
+            new GateResult(status: 'FAILED', details: details)
+        }
+    }
+
+    private static final class CspAggregation {
+        boolean clean = true
+        String generalMessage
+        Map<String, List<String>> issuesByGuide = [:].withDefault { [] }
+    }
+
+    private static final class AcceptanceRow {
+        String guide
+        String version
+        String asciidoctorWarningGate
+        String crawlBuiltGuides
+        String structuralDiffGuides
+        String cspScan
+        String verdict
+        String details
+    }
+}

--- a/buildSrc/src/main/groovy/website/gradle/tasks/AsciidoctorWarningGateTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/AsciidoctorWarningGateTask.groovy
@@ -69,31 +69,41 @@ class AsciidoctorWarningGateTask extends DefaultTask {
     @Input
     final ListProperty<String> guideTaskMappings = project.objects.listProperty(String)
 
+    @Input
+    @Optional
+    final ListProperty<String> allowlistPatterns = project.objects.listProperty(String)
+
     @TaskAction
     void gate() {
         File logsRoot = logDir.get().asFile
         File report = reportFile.get().asFile
 
-        if (!logsRoot.isDirectory()) {
-            writeCsv(report, [])
-            return
-        }
-
         Map<String, GuideTaskMetadata> metadataByTaskName = parseGuideTaskMappings(guideTaskMappings.get())
+        List<Pattern> compiledAllowlist = compileAllowlist(allowlistPatterns.getOrElse([] as List<String>))
         List<GuideSummary> results = []
 
         for (GuideTaskMetadata metadata : metadataByTaskName.values()) {
             File logFile = new File(logsRoot, "asciidoctor-${metadata.taskName}.log")
-            List<String> violations = logFile.isFile() ? findViolations(logFile) : []
-            String status = statusFor(violations.isEmpty())
-            String details = violations.isEmpty()
-                    ? 'No unallowlisted warning or error lines detected.'
-                    : abbreviate(violations.join(' | '))
+            String status
+            int issueCount
+            String details
+            if (!logFile.isFile()) {
+                status = 'REVIEW'
+                issueCount = 0
+                details = "Missing captured log output for ${metadata.taskName}; rerun the renderer or invalidate Gradle caches before trusting this verdict.".toString()
+            } else {
+                List<String> violations = findViolations(logFile, compiledAllowlist)
+                status = statusFor(violations.isEmpty())
+                issueCount = violations.size()
+                details = violations.isEmpty()
+                        ? 'No unallowlisted warning or error lines detected.'
+                        : abbreviate(violations.join(' | '))
+            }
             results << new GuideSummary(
                     guide: metadata.guide,
                     version: metadata.version,
                     status: status,
-                    issueCount: violations.size(),
+                    issueCount: issueCount,
                     details: details,
             )
         }
@@ -106,6 +116,17 @@ class AsciidoctorWarningGateTask extends DefaultTask {
         }
     }
 
+    private static List<Pattern> compileAllowlist(List<String> patterns) {
+        List<Pattern> compiled = []
+        for (String raw : patterns) {
+            String trimmed = raw?.trim()
+            if (trimmed) {
+                compiled.add(Pattern.compile(trimmed))
+            }
+        }
+        compiled
+    }
+
     static TaskProvider<AsciidoctorWarningGateTask> register(Project project) {
         wireLogCapture(project)
         project.tasks.register(NAME, AsciidoctorWarningGateTask) { AsciidoctorWarningGateTask task ->
@@ -116,6 +137,7 @@ class AsciidoctorWarningGateTask extends DefaultTask {
             task.reportFile.convention(project.layout.buildDirectory.file('reports/asciidoctor-warning-gate.csv'))
             task.failOnViolation.convention(isHardFailMode(project))
             task.guideTaskMappings.set(buildGuideTaskMappings(project))
+            task.allowlistPatterns.convention(parseAllowlistProperty(project))
             task.dependsOn('buildAllGuides')
         }
     }
@@ -163,9 +185,8 @@ class AsciidoctorWarningGateTask extends DefaultTask {
         }
     }
 
-    private static List<String> findViolations(File logFile) {
+    private static List<String> findViolations(File logFile, List<Pattern> excludeAllowlist) {
         List<String> violations = []
-        List<Pattern> excludeAllowlist = []
         int lineNumber = 0
         logFile.eachLine('UTF-8') { String line ->
             lineNumber++
@@ -174,6 +195,14 @@ class AsciidoctorWarningGateTask extends DefaultTask {
             }
         }
         violations
+    }
+
+    private static List<String> parseAllowlistProperty(Project project) {
+        Object raw = project.findProperty('asciidoctorAllowlist')
+        if (!raw) {
+            return [] as List<String>
+        }
+        ((raw as String).split(',') as List<String>).collect { String token -> token?.trim() }.findAll { String token -> token } as List<String>
     }
 
     private static boolean isAllowlisted(String line, List<Pattern> excludeAllowlist) {

--- a/buildSrc/src/main/groovy/website/gradle/tasks/AsciidoctorWarningGateTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/AsciidoctorWarningGateTask.groovy
@@ -1,0 +1,274 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package website.gradle.tasks
+
+import groovy.transform.CompileStatic
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.plugins.ExtraPropertiesExtension
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.logging.StandardOutputListener
+
+import grails.doc.gradle.PublishGuideTask
+
+import java.util.regex.Pattern
+
+/**
+ * Scans captured PublishGuide output for unallowlisted warnings and errors and
+ * writes a per-guide summary to {@code build/reports/asciidoctor-warning-gate.csv}.
+ */
+@CompileStatic
+class AsciidoctorWarningGateTask extends DefaultTask {
+
+    static final String NAME = 'asciidoctorWarningGate'
+    static final String GROUP = 'migration'
+
+    private static final Pattern WARNING_PATTERN = ~/(?im)^.*(\[WARNING\]|\[ERROR\]|asciidoctor:\s*(WARNING|ERROR|FAIL)|\bWARN(?:ING)?:|\bERROR:|java\.lang\.\w+(?:Error|Exception)|java\.io\.\w+(?:Error|Exception)|java\.util\.\w+(?:Error|Exception)|org\.\w+(?:\.\w+)*\.\w+(?:Error|Exception)|^.*Caused by:)/
+
+    @Optional
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
+    final DirectoryProperty logDir = project.objects.directoryProperty()
+
+    @OutputFile
+    final RegularFileProperty reportFile = project.objects.fileProperty()
+
+    @Input
+    final Property<Boolean> failOnViolation = project.objects.property(Boolean)
+
+    @Input
+    final ListProperty<String> guideTaskMappings = project.objects.listProperty(String)
+
+    @TaskAction
+    void gate() {
+        File logsRoot = logDir.get().asFile
+        File report = reportFile.get().asFile
+
+        if (!logsRoot.isDirectory()) {
+            writeCsv(report, [])
+            return
+        }
+
+        Map<String, GuideTaskMetadata> metadataByTaskName = parseGuideTaskMappings(guideTaskMappings.get())
+        List<GuideSummary> results = []
+
+        for (GuideTaskMetadata metadata : metadataByTaskName.values()) {
+            File logFile = new File(logsRoot, "asciidoctor-${metadata.taskName}.log")
+            List<String> violations = logFile.isFile() ? findViolations(logFile) : []
+            String status = statusFor(violations.isEmpty())
+            String details = violations.isEmpty()
+                    ? 'No unallowlisted warning or error lines detected.'
+                    : abbreviate(violations.join(' | '))
+            results << new GuideSummary(
+                    guide: metadata.guide,
+                    version: metadata.version,
+                    status: status,
+                    issueCount: violations.size(),
+                    details: details,
+            )
+        }
+
+        writeCsv(report, results)
+
+        List<GuideSummary> failed = results.findAll { GuideSummary result -> result.status == 'FAILED' } as List<GuideSummary>
+        if (!failed.isEmpty()) {
+            throw new GradleException("AsciiDoctor warnings detected. See ${report.absolutePath}.")
+        }
+    }
+
+    static TaskProvider<AsciidoctorWarningGateTask> register(Project project) {
+        wireLogCapture(project)
+        project.tasks.register(NAME, AsciidoctorWarningGateTask) { AsciidoctorWarningGateTask task ->
+            task.group = GROUP
+            task.description = 'Captures PublishGuide output and summarizes unallowlisted AsciiDoctor warnings and errors.'
+            task.notCompatibleWithConfigurationCache('Reads per-guide log capture emitted by vendored PublishGuide tasks and their finalizers.')
+            task.logDir.convention(project.layout.buildDirectory.dir('logs'))
+            task.reportFile.convention(project.layout.buildDirectory.file('reports/asciidoctor-warning-gate.csv'))
+            task.failOnViolation.convention(isHardFailMode(project))
+            task.guideTaskMappings.set(buildGuideTaskMappings(project))
+            task.dependsOn('buildAllGuides')
+        }
+    }
+
+    private static void wireLogCapture(Project project) {
+        project.tasks.withType(PublishGuideTask).all { PublishGuideTask renderTask ->
+            File logsRoot = project.layout.buildDirectory.dir('logs').get().asFile
+            File logFile = new File(logsRoot, "asciidoctor-${renderTask.name}.log")
+
+            renderTask.doFirst {
+                logsRoot.mkdirs()
+                logFile.text = ''
+
+                StandardOutputListener writeListener = ({ CharSequence message ->
+                    logFile << message
+                } as StandardOutputListener)
+
+                renderTask.logging.addStandardOutputListener(writeListener)
+                renderTask.logging.addStandardErrorListener(writeListener)
+
+                ExtraPropertiesExtension extraProperties = renderTask.extensions.extraProperties
+                extraProperties.set('logFile', logFile)
+                extraProperties.set('logListener', writeListener)
+            }
+
+            String cleanupTaskName = "cleanup-${renderTask.name}-logs"
+            if (project.tasks.findByName(cleanupTaskName) == null) {
+                project.tasks.register(cleanupTaskName) { Task cleanupTask ->
+                    cleanupTask.notCompatibleWithConfigurationCache('Removes StandardOutputListener instances from PublishGuide tasks.')
+                    cleanupTask.doLast {
+                        try {
+                            ExtraPropertiesExtension extraProperties = renderTask.extensions.extraProperties
+                            if (extraProperties.has('logListener')) {
+                                StandardOutputListener writeListener = extraProperties.get('logListener') as StandardOutputListener
+                                renderTask.logging.removeStandardOutputListener(writeListener)
+                                renderTask.logging.removeStandardErrorListener(writeListener)
+                            }
+                        } catch (Exception e) {
+                            project.logger.warn("Listener cleanup failed for ${renderTask.name}: ${e.message}")
+                        }
+                    }
+                }
+            }
+            renderTask.finalizedBy(cleanupTaskName)
+        }
+    }
+
+    private static List<String> findViolations(File logFile) {
+        List<String> violations = []
+        List<Pattern> excludeAllowlist = []
+        int lineNumber = 0
+        logFile.eachLine('UTF-8') { String line ->
+            lineNumber++
+            if (WARNING_PATTERN.matcher(line).find() && !isAllowlisted(line, excludeAllowlist)) {
+                violations.add("${logFile.name}:${lineNumber}:${sanitize(line)}".toString())
+            }
+        }
+        violations
+    }
+
+    private static boolean isAllowlisted(String line, List<Pattern> excludeAllowlist) {
+        for (Pattern pattern : excludeAllowlist) {
+            if (pattern.matcher(line).find()) {
+                return true
+            }
+        }
+        false
+    }
+
+    private static List<String> buildGuideTaskMappings(Project project) {
+        List<String> mappings = []
+        File buildDir = project.layout.buildDirectory.get().asFile
+        String buildPrefix = buildDir.absolutePath.replace('\\', '/')
+        project.tasks.withType(PublishGuideTask).each { PublishGuideTask renderTask ->
+            File targetDir = renderTask.targetDir.get().asFile
+            String normalizedTarget = targetDir.absolutePath.replace('\\', '/')
+            String relativePath = normalizedTarget.startsWith(buildPrefix)
+                    ? normalizedTarget.substring(buildPrefix.length()).replaceFirst('^/+', '')
+                    : normalizedTarget
+            List<String> segments = relativePath.tokenize('/')
+            if (segments.size() >= 4 && segments[0] == 'dist' && segments[1] == 'guides') {
+                mappings.add("${renderTask.name}|${segments[2]}|${segments[3]}".toString())
+            }
+        }
+        mappings
+    }
+
+    private static Map<String, GuideTaskMetadata> parseGuideTaskMappings(List<String> mappings) {
+        Map<String, GuideTaskMetadata> metadataByTaskName = [:]
+        for (String mapping : mappings) {
+            List<String> parts = mapping.tokenize('|')
+            if (parts.size() == 3) {
+                metadataByTaskName[parts[0]] = new GuideTaskMetadata(
+                        taskName: parts[0],
+                        guide: parts[1],
+                        version: parts[2],
+                )
+            }
+        }
+        metadataByTaskName
+    }
+
+    private String statusFor(boolean clean) {
+        if (clean) {
+            return 'VERIFIED'
+        }
+        failOnViolation.get() ? 'FAILED' : 'REVIEW'
+    }
+
+    private static boolean isHardFailMode(Project project) {
+        String mode = (project.findProperty('verificationMode') ?: '') as String
+        mode.equalsIgnoreCase('hard-fail')
+    }
+
+    private static void writeCsv(File outputFile, List<GuideSummary> results) {
+        outputFile.parentFile.mkdirs()
+        StringBuilder sb = new StringBuilder('guide,version,status,issueCount,details\n')
+        for (GuideSummary result : results) {
+            sb << sanitize(result.guide) << ','
+            sb << sanitize(result.version) << ','
+            sb << sanitize(result.status) << ','
+            sb << result.issueCount << ','
+            sb << sanitize(result.details) << '\n'
+        }
+        outputFile.text = sb.toString()
+    }
+
+    private static String abbreviate(String value) {
+        if (value.size() <= 1200) {
+            return value
+        }
+        value.substring(0, 1197) + '...'
+    }
+
+    private static String sanitize(String value) {
+        (value ?: '')
+                .replace('\r', ' ')
+                .replace('\n', ' ')
+                .replace(',', ';')
+                .trim()
+    }
+
+    private static final class GuideTaskMetadata {
+        String taskName
+        String guide
+        String version
+    }
+
+    private static final class GuideSummary {
+        String guide
+        String version
+        String status
+        int issueCount
+        String details
+    }
+}

--- a/buildSrc/src/main/groovy/website/gradle/tasks/CrawlBuiltGuidesTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/CrawlBuiltGuidesTask.groovy
@@ -1,0 +1,353 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package website.gradle.tasks
+
+import groovy.transform.CompileStatic
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
+
+/**
+ * Crawls rendered guide HTML looking for missing local files and broken anchors.
+ */
+@CompileStatic
+class CrawlBuiltGuidesTask extends DefaultTask {
+
+    static final String NAME = 'crawlBuiltGuides'
+    static final String GROUP = 'migration'
+
+    @Optional
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
+    final DirectoryProperty guidesDir = project.objects.directoryProperty()
+
+    @Optional
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
+    final DirectoryProperty siteRootDir = project.objects.directoryProperty()
+
+    @OutputFile
+    final RegularFileProperty reportFile = project.objects.fileProperty()
+
+    @Input
+    final Property<Boolean> failOnViolation = project.objects.property(Boolean)
+
+    @TaskAction
+    void crawl() {
+        File guidesRoot = guidesDir.get().asFile
+        File siteRoot = siteRootDir.get().asFile
+        File report = reportFile.get().asFile
+
+        if (!guidesRoot.isDirectory()) {
+            writeCsv(report, [])
+            return
+        }
+
+        Map<String, GuideSummary> summaries = discoverGuideVersions(guidesRoot)
+        Map<File, Document> documentCache = [:]
+        Map<File, Set<String>> anchorCache = [:]
+
+        for (GuideSummary summary : summaries.values()) {
+            List<File> htmlFiles = collectHtmlFiles(summary.versionDir)
+            if (htmlFiles.isEmpty()) {
+                summary.issues << 'No rendered HTML files were found for this guide version.'
+                continue
+            }
+            for (File htmlFile : htmlFiles) {
+                Document document = parseDocument(htmlFile, documentCache)
+                checkLinkElements(summary, htmlFile, document, siteRoot, documentCache, anchorCache)
+            }
+        }
+
+        List<GuideSummary> results = summaries.values() as List<GuideSummary>
+        for (GuideSummary summary : results) {
+            summary.status = determineStatus(summary.issues.isEmpty())
+        }
+        writeCsv(report, results)
+
+        List<GuideSummary> failed = results.findAll { GuideSummary summary -> summary.status == 'FAILED' } as List<GuideSummary>
+        if (!failed.isEmpty()) {
+            throw new GradleException("Broken rendered guide references detected. See ${report.absolutePath}.")
+        }
+    }
+
+    static TaskProvider<CrawlBuiltGuidesTask> register(Project project) {
+        project.tasks.register(NAME, CrawlBuiltGuidesTask) { CrawlBuiltGuidesTask task ->
+            task.group = GROUP
+            task.description = 'Smoke-crawls rendered guide HTML for broken local links, assets, and anchors.'
+            task.guidesDir.convention(project.layout.buildDirectory.dir('dist/guides'))
+            task.siteRootDir.convention(project.layout.buildDirectory.dir('dist'))
+            task.reportFile.convention(project.layout.buildDirectory.file('reports/crawl-built-guides.csv'))
+            task.failOnViolation.convention(isHardFailMode(project))
+            task.dependsOn('buildAllGuides')
+        }
+    }
+
+    private void checkLinkElements(GuideSummary summary, File htmlFile, Document document, File siteRoot,
+            Map<File, Document> documentCache, Map<File, Set<String>> anchorCache) {
+        checkElements(summary, htmlFile, document, siteRoot, documentCache, anchorCache, 'a[href]', 'href', true)
+        checkElements(summary, htmlFile, document, siteRoot, documentCache, anchorCache, 'img[src]', 'src', false)
+        checkElements(summary, htmlFile, document, siteRoot, documentCache, anchorCache, 'link[href]', 'href', false)
+        checkElements(summary, htmlFile, document, siteRoot, documentCache, anchorCache, 'script[src]', 'src', false)
+    }
+
+    private void checkElements(GuideSummary summary, File htmlFile, Document document, File siteRoot,
+            Map<File, Document> documentCache, Map<File, Set<String>> anchorCache,
+            String selector, String attribute, boolean checkAnchor) {
+
+        for (Element element : document.select(selector)) {
+            String reference = element.attr(attribute)?.trim()
+            if (shouldIgnore(reference)) {
+                continue
+            }
+
+            ReferenceParts parts = splitReference(reference)
+            if (parts.pathPart.isEmpty()) {
+                if (checkAnchor && !parts.fragment.isEmpty()) {
+                    ensureAnchor(summary, htmlFile, htmlFile, parts.fragment, documentCache, anchorCache)
+                }
+                continue
+            }
+
+            File target = resolveTarget(htmlFile, siteRoot, parts.pathPart)
+            if (!target.isFile()) {
+                summary.issues.add("${relativePath(summary.versionDir, htmlFile)} -> missing ${attribute} target ${parts.pathPart}".toString())
+                continue
+            }
+            if (checkAnchor && !parts.fragment.isEmpty()) {
+                ensureAnchor(summary, htmlFile, target, parts.fragment, documentCache, anchorCache)
+            }
+        }
+    }
+
+    private void ensureAnchor(GuideSummary summary, File sourceFile, File targetFile, String fragment,
+            Map<File, Document> documentCache, Map<File, Set<String>> anchorCache) {
+        Set<String> anchors = anchorCache.computeIfAbsent(targetFile) {
+            extractAnchors(parseDocument(targetFile, documentCache))
+        }
+        if (!anchors.contains(fragment)) {
+            summary.issues.add("${relativePath(summary.versionDir, sourceFile)} -> missing anchor #${fragment} in ${relativePath(summary.versionDir, targetFile)}".toString())
+        }
+    }
+
+    private static Map<String, GuideSummary> discoverGuideVersions(File guidesRoot) {
+        Map<String, GuideSummary> summaries = [:]
+        File[] guideDirs = guidesRoot.listFiles()
+        if (guideDirs == null) {
+            return summaries
+        }
+        for (File guideDir : guideDirs) {
+            if (!guideDir.isDirectory()) {
+                continue
+            }
+            File[] versionDirs = guideDir.listFiles()
+            if (versionDirs == null) {
+                continue
+            }
+            for (File versionDir : versionDirs) {
+                if (!versionDir.isDirectory()) {
+                    continue
+                }
+                GuideSummary summary = new GuideSummary(
+                        guide: guideDir.name,
+                        version: versionDir.name,
+                        versionDir: versionDir,
+                )
+                summaries[keyFor(guideDir.name, versionDir.name)] = summary
+            }
+        }
+        summaries
+    }
+
+    private static List<File> collectHtmlFiles(File versionDir) {
+        List<File> htmlFiles = []
+        versionDir.eachFileRecurse { File candidate ->
+            if (candidate.isFile() && candidate.name.endsWith('.html')) {
+                htmlFiles << candidate
+            }
+        }
+        htmlFiles.sort { File left, File right -> left.absolutePath <=> right.absolutePath }
+        htmlFiles
+    }
+
+    private static Document parseDocument(File htmlFile, Map<File, Document> documentCache) {
+        documentCache.computeIfAbsent(htmlFile) {
+            Jsoup.parse(htmlFile, 'UTF-8')
+        }
+    }
+
+    private static Set<String> extractAnchors(Document document) {
+        Set<String> anchors = [] as LinkedHashSet<String>
+        for (Element element : document.select('[id]')) {
+            String id = element.attr('id')?.trim()
+            if (!id.isEmpty()) {
+                anchors << id
+            }
+        }
+        for (Element element : document.select('a[name]')) {
+            String name = element.attr('name')?.trim()
+            if (!name.isEmpty()) {
+                anchors << name
+            }
+        }
+        anchors
+    }
+
+    private static File resolveTarget(File htmlFile, File siteRoot, String rawPath) {
+        String decoded = URLDecoder.decode(rawPath, StandardCharsets.UTF_8)
+        Path candidate = decoded.startsWith('/')
+                ? siteRoot.toPath().resolve(decoded.substring(1))
+                : htmlFile.parentFile.toPath().resolve(decoded)
+        Path normalized = candidate.normalize()
+        File target = normalized.toFile()
+        if (target.isDirectory()) {
+            return normalized.resolve('index.html').toFile()
+        }
+        if (!target.exists() && !decoded.contains('.') && normalized.resolveSibling(normalized.fileName.toString() + '.html').toFile().isFile()) {
+            return normalized.resolveSibling(normalized.fileName.toString() + '.html').toFile()
+        }
+        if (!target.exists() && normalized.resolve('index.html').toFile().isFile()) {
+            return normalized.resolve('index.html').toFile()
+        }
+        target
+    }
+
+    private String determineStatus(boolean clean) {
+        if (clean) {
+            return 'VERIFIED'
+        }
+        failOnViolation.get() ? 'FAILED' : 'REVIEW'
+    }
+
+    private static ReferenceParts splitReference(String reference) {
+        String noQuery = reference
+        int queryIndex = noQuery.indexOf('?')
+        if (queryIndex >= 0) {
+            noQuery = noQuery.substring(0, queryIndex)
+        }
+        int hashIndex = noQuery.indexOf('#')
+        if (hashIndex < 0) {
+            return new ReferenceParts(pathPart: noQuery, fragment: '')
+        }
+        new ReferenceParts(
+                pathPart: noQuery.substring(0, hashIndex),
+                fragment: noQuery.substring(hashIndex + 1),
+        )
+    }
+
+    private static boolean shouldIgnore(String reference) {
+        if (reference == null) {
+            return true
+        }
+        String value = reference.trim()
+        if (value.isEmpty() || value == '#') {
+            return true
+        }
+        String lower = value.toLowerCase(Locale.ENGLISH)
+        lower.startsWith('http://') ||
+                lower.startsWith('https://') ||
+                lower.startsWith('mailto:') ||
+                lower.startsWith('tel:') ||
+                lower.startsWith('javascript:') ||
+                lower.startsWith('data:') ||
+                lower.startsWith('blob:') ||
+                lower.startsWith('//')
+    }
+
+    private static void writeCsv(File outputFile, List<GuideSummary> results) {
+        outputFile.parentFile.mkdirs()
+        StringBuilder sb = new StringBuilder('guide,version,status,issueCount,details\n')
+        for (GuideSummary result : results.sort { GuideSummary left, GuideSummary right ->
+            int guideCompare = left.guide <=> right.guide
+            guideCompare != 0 ? guideCompare : (left.version <=> right.version)
+        }) {
+            List<String> issues = result.issues as List<String>
+            String details = issues.isEmpty()
+                    ? 'No broken local references or anchors detected.'
+                    : abbreviate(issues.join(' | '))
+            sb << sanitize(result.guide) << ','
+            sb << sanitize(result.version) << ','
+            sb << sanitize(result.status ?: 'VERIFIED') << ','
+            sb << issues.size() << ','
+            sb << sanitize(details) << '\n'
+        }
+        outputFile.text = sb.toString()
+    }
+
+    private static String keyFor(String guide, String version) {
+        guide + '|' + version
+    }
+
+    private static String relativePath(File root, File file) {
+        root.toPath().relativize(file.toPath()).toString().replace('\\', '/')
+    }
+
+    private static boolean isHardFailMode(Project project) {
+        String mode = (project.findProperty('verificationMode') ?: '') as String
+        mode.equalsIgnoreCase('hard-fail')
+    }
+
+    private static String abbreviate(String value) {
+        if (value.size() <= 1200) {
+            return value
+        }
+        value.substring(0, 1197) + '...'
+    }
+
+    private static String sanitize(String value) {
+        (value ?: '')
+                .replace('\r', ' ')
+                .replace('\n', ' ')
+                .replace(',', ';')
+                .trim()
+    }
+
+    private static final class ReferenceParts {
+        String pathPart
+        String fragment
+    }
+
+    private static final class GuideSummary {
+        String guide
+        String version
+        String status
+        File versionDir
+        Set<String> issues = [] as LinkedHashSet<String>
+    }
+}

--- a/buildSrc/src/main/groovy/website/gradle/tasks/CrawlBuiltGuidesTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/CrawlBuiltGuidesTask.groovy
@@ -234,7 +234,15 @@ class CrawlBuiltGuidesTask extends DefaultTask {
         Path candidate = decoded.startsWith('/')
                 ? siteRoot.toPath().resolve(decoded.substring(1))
                 : htmlFile.parentFile.toPath().resolve(decoded)
-        Path normalized = candidate.normalize()
+        Path normalized = candidate.normalize().toAbsolutePath()
+        Path siteRootCanonical = siteRoot.toPath().normalize().toAbsolutePath()
+        if (!normalized.startsWith(siteRootCanonical)) {
+            // The reference escapes the deployed site tree. Treat it as broken
+            // rather than probing arbitrary files on the build host. The caller
+            // checks isFile() on the return value, so a non-existent path under
+            // siteRoot triggers the "missing target" branch.
+            return siteRootCanonical.resolve('__path_traversal_rejected__/' + decoded.replace('/', '_').replace('\\', '_')).toFile()
+        }
         File target = normalized.toFile()
         if (target.isDirectory()) {
             return normalized.resolve('index.html').toFile()

--- a/buildSrc/src/main/groovy/website/gradle/tasks/CspScanTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/CspScanTask.groovy
@@ -58,7 +58,7 @@ import org.yaml.snakeyaml.Yaml
 class CspScanTask extends DefaultTask {
 
     static final String NAME = 'cspScan'
-    static final String GROUP = 'documentation'
+    static final String GROUP = 'migration'
 
     @InputDirectory
     @PathSensitive(PathSensitivity.RELATIVE)
@@ -205,9 +205,16 @@ class CspScanTask extends DefaultTask {
             task.allowlistFile.set(
                     project.rootProject.layout.projectDirectory.file('conf/csp-allowlist.yml'))
             task.reportFile.set(project.layout.buildDirectory.file('reports/csp-scan.md'))
+            task.failOnViolation.convention(isHardFailMode(project))
+            task.dependsOn('buildAllGuides')
             if (project.hasProperty('cspFailOnViolation')) {
                 task.failOnViolation.set(Boolean.parseBoolean(project.property('cspFailOnViolation') as String))
             }
         }
+    }
+
+    private static boolean isHardFailMode(Project project) {
+        String mode = (project.findProperty('verificationMode') ?: '') as String
+        mode.equalsIgnoreCase('hard-fail')
     }
 }

--- a/buildSrc/src/main/groovy/website/gradle/tasks/CspScanTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/CspScanTask.groovy
@@ -50,9 +50,15 @@ import org.yaml.snakeyaml.Yaml
  * <p>The intent is to catch resources loaded from third-party origins
  * before they become Content Security Policy violations on the live site.</p>
  *
- * <p>By default, presence of any unknown-host reference fails the build.
- * Use {@code -PcspFailOnViolation=false} to demote to warnings while
- * iterating.</p>
+ * <p>Failure mode is staged. Default is report-only (does not fail the build),
+ * matching the verification harness pattern from {@code verifyAllGuides}.
+ * Override precedence (highest first):</p>
+ * <ol>
+ *   <li>{@code -PcspFailOnViolation=true|false} - explicit per-task switch.</li>
+ *   <li>{@code -PverificationMode=hard-fail} - turns the verification harness
+ *       into hard-fail mode for every gate, including this one.</li>
+ *   <li>Default: report-only (build does not fail on violations).</li>
+ * </ol>
  */
 @CompileStatic
 class CspScanTask extends DefaultTask {

--- a/buildSrc/src/main/groovy/website/gradle/tasks/StructuralDiffGuidesTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/StructuralDiffGuidesTask.groovy
@@ -58,8 +58,10 @@ class StructuralDiffGuidesTask extends DefaultTask {
     @PathSensitive(PathSensitivity.RELATIVE)
     final DirectoryProperty guidesDir = project.objects.directoryProperty()
 
-    @Input
-    final Property<String> baselineDirPath = project.objects.property(String)
+    @Optional
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
+    final DirectoryProperty baselineDir = project.objects.directoryProperty()
 
     @OutputDirectory
     final DirectoryProperty fingerprintDir = project.objects.directoryProperty()
@@ -73,7 +75,7 @@ class StructuralDiffGuidesTask extends DefaultTask {
     @TaskAction
     void diff() {
         File guidesRoot = guidesDir.get().asFile
-        File baselinesRoot = new File(baselineDirPath.get())
+        File baselinesRoot = baselineDir.isPresent() ? baselineDir.get().asFile : null
         File fingerprintsRoot = fingerprintDir.get().asFile
         File report = reportFile.get().asFile
 
@@ -104,7 +106,13 @@ class StructuralDiffGuidesTask extends DefaultTask {
             task.group = GROUP
             task.description = 'Extracts structural fingerprints from rendered guides and compares them with available baselines.'
             task.guidesDir.convention(project.layout.buildDirectory.dir('dist/guides'))
-            task.baselineDirPath.convention(project.rootProject.layout.projectDirectory.dir('buildSrc/src/test/resources/structural-baseline').asFile.absolutePath)
+            // baselineDir is optional. If the directory exists at config time we point at it;
+            // otherwise we leave the property unset so structuralDiff still produces fingerprints
+            // without attempting baseline comparison (every row lands as REVIEW pending a snapshot).
+            File defaultBaseline = project.rootProject.layout.projectDirectory.dir('buildSrc/src/test/resources/structural-baseline').asFile
+            if (defaultBaseline.isDirectory()) {
+                task.baselineDir.convention(project.rootProject.layout.projectDirectory.dir('buildSrc/src/test/resources/structural-baseline'))
+            }
             task.fingerprintDir.convention(project.layout.buildDirectory.dir('reports/structural-fingerprints'))
             task.reportFile.convention(project.layout.buildDirectory.file('reports/structural-diff-guides.csv'))
             task.failOnViolation.convention(isHardFailMode(project))
@@ -237,7 +245,7 @@ class StructuralDiffGuidesTask extends DefaultTask {
 
     private static File resolveBaselineFile(File baselinesRoot, String guideName, String version) {
         // TODO: Integrate captured production baseline snapshots from https://guides.grails.org/<guide>/<version>/ once they are committed.
-        if (!baselinesRoot.isDirectory()) {
+        if (baselinesRoot == null || !baselinesRoot.isDirectory()) {
             return null
         }
         List<String> candidates = [

--- a/buildSrc/src/main/groovy/website/gradle/tasks/StructuralDiffGuidesTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/StructuralDiffGuidesTask.groovy
@@ -1,0 +1,331 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package website.gradle.tasks
+
+import groovy.json.JsonOutput
+import groovy.transform.CompileStatic
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+
+import website.qa.AdHocFixtureDiff
+
+/**
+ * Extracts structural fingerprints from rendered guides and compares them to a
+ * baseline when one is available.
+ */
+@CompileStatic
+class StructuralDiffGuidesTask extends DefaultTask {
+
+    static final String NAME = 'structuralDiffGuides'
+    static final String GROUP = 'migration'
+
+    @Optional
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
+    final DirectoryProperty guidesDir = project.objects.directoryProperty()
+
+    @Input
+    final Property<String> baselineDirPath = project.objects.property(String)
+
+    @OutputDirectory
+    final DirectoryProperty fingerprintDir = project.objects.directoryProperty()
+
+    @OutputFile
+    final RegularFileProperty reportFile = project.objects.fileProperty()
+
+    @Input
+    final Property<Boolean> failOnViolation = project.objects.property(Boolean)
+
+    @TaskAction
+    void diff() {
+        File guidesRoot = guidesDir.get().asFile
+        File baselinesRoot = new File(baselineDirPath.get())
+        File fingerprintsRoot = fingerprintDir.get().asFile
+        File report = reportFile.get().asFile
+
+        if (!guidesRoot.isDirectory()) {
+            writeCsv(report, [])
+            return
+        }
+
+        List<GuideSummary> results = []
+        for (File guideDir : sortedDirectories(guidesRoot)) {
+            for (File versionDir : sortedDirectories(guideDir)) {
+                GuideSummary summary = inspectGuideVersion(guideDir.name, versionDir, baselinesRoot, fingerprintsRoot)
+                summary.status = determineStatus(summary)
+                results << summary
+            }
+        }
+
+        writeCsv(report, results)
+
+        List<GuideSummary> failed = results.findAll { GuideSummary summary -> summary.status == 'FAILED' } as List<GuideSummary>
+        if (!failed.isEmpty()) {
+            throw new GradleException("Structural guide differences detected. See ${report.absolutePath}.")
+        }
+    }
+
+    static TaskProvider<StructuralDiffGuidesTask> register(Project project) {
+        project.tasks.register(NAME, StructuralDiffGuidesTask) { StructuralDiffGuidesTask task ->
+            task.group = GROUP
+            task.description = 'Extracts structural fingerprints from rendered guides and compares them with available baselines.'
+            task.guidesDir.convention(project.layout.buildDirectory.dir('dist/guides'))
+            task.baselineDirPath.convention(project.rootProject.layout.projectDirectory.dir('buildSrc/src/test/resources/structural-baseline').asFile.absolutePath)
+            task.fingerprintDir.convention(project.layout.buildDirectory.dir('reports/structural-fingerprints'))
+            task.reportFile.convention(project.layout.buildDirectory.file('reports/structural-diff-guides.csv'))
+            task.failOnViolation.convention(isHardFailMode(project))
+            task.dependsOn('buildAllGuides')
+        }
+    }
+
+    private GuideSummary inspectGuideVersion(String guideName, File versionDir, File baselinesRoot, File fingerprintsRoot) {
+        GuideSummary summary = new GuideSummary(
+                guide: guideName,
+                version: versionDir.name,
+        )
+
+        File renderedFile = locateRenderedFile(versionDir)
+        if (renderedFile == null) {
+            summary.differences << 'No guide/single.html, guide/index.html, or index.html was found for this rendered guide version.'
+            return summary
+        }
+
+        Fingerprint localFingerprint = fingerprint(renderedFile, versionDir)
+        writeFingerprint(new File(fingerprintsRoot, "${guideName}/${versionDir.name}.json"), localFingerprint)
+
+        File baselineFile = resolveBaselineFile(baselinesRoot, guideName, versionDir.name)
+        Fingerprint baselineFingerprint = baselineFile == null
+                ? localFingerprint
+                : fingerprint(baselineFile, baselineFile.parentFile)
+        boolean selfBaseline = baselineFile == null
+        summary.selfBaseline = selfBaseline
+
+        if (localFingerprint.headingTree.isEmpty()) {
+            summary.differences.add("${localFingerprint.sourcePath} contains no headings.".toString())
+        }
+        if (localFingerprint.totalAnchors == 0) {
+            summary.differences.add("${localFingerprint.sourcePath} contains no anchor IDs.".toString())
+        }
+
+        if (!selfBaseline) {
+            summary.differences.addAll(compare(localFingerprint, baselineFingerprint))
+        }
+
+        if (selfBaseline && summary.differences.isEmpty()) {
+            summary.differencesInfo = 'Fingerprint extracted successfully. Baseline comparison is currently self-referential until production snapshots are checked in.'
+        } else if (selfBaseline) {
+            summary.differencesInfo = 'Fingerprint extracted successfully, but the rendered file itself contains structural issues.'
+        } else {
+            summary.differencesInfo = "Compared ${localFingerprint.sourcePath} to ${baselineFingerprint.sourcePath}."
+        }
+        summary
+    }
+
+    private String determineStatus(GuideSummary summary) {
+        if (!summary.differences.isEmpty()) {
+            return failOnViolation.get() ? 'FAILED' : 'REVIEW'
+        }
+        summary.selfBaseline ? 'REVIEW' : 'VERIFIED'
+    }
+
+    private static List<String> compare(Fingerprint localFingerprint, Fingerprint baselineFingerprint) {
+        List<String> differences = []
+        if (localFingerprint.headingTree != baselineFingerprint.headingTree) {
+            differences.add("Heading tree mismatch: local=${localFingerprint.headingTree.size()} baseline=${baselineFingerprint.headingTree.size()}".toString())
+        }
+        Set<String> missingAnchors = baselineFingerprint.anchorIds - localFingerprint.anchorIds
+        if (!missingAnchors.isEmpty()) {
+            differences.add("${missingAnchors.size()} anchor IDs are missing from the rendered output.".toString())
+        }
+        if (localFingerprint.totalHeadings != baselineFingerprint.totalHeadings) {
+            differences.add("Heading count drift: local=${localFingerprint.totalHeadings} baseline=${baselineFingerprint.totalHeadings}".toString())
+        }
+        if (localFingerprint.sectionCount != baselineFingerprint.sectionCount) {
+            differences.add("Section count drift: local=${localFingerprint.sectionCount} baseline=${baselineFingerprint.sectionCount}".toString())
+        }
+        if (localFingerprint.codeBlockCount != baselineFingerprint.codeBlockCount) {
+            differences.add("Code block count drift: local=${localFingerprint.codeBlockCount} baseline=${baselineFingerprint.codeBlockCount}".toString())
+        }
+        if (localFingerprint.imageCount != baselineFingerprint.imageCount) {
+            differences.add("Image count drift: local=${localFingerprint.imageCount} baseline=${baselineFingerprint.imageCount}".toString())
+        }
+        differences
+    }
+
+    private static Fingerprint fingerprint(File htmlFile, File versionRoot) {
+        Document document = Jsoup.parse(htmlFile, 'UTF-8')
+        AdHocFixtureDiff.Metrics metrics = AdHocFixtureDiff.measure(document)
+        List<String> headingTree = []
+        for (Element element : document.select('h1, h2, h3, h4, h5, h6')) {
+            String text = normalizeText(element.text())
+            if (!text.isEmpty()) {
+                headingTree.add("${element.tagName()}:${text}".toString())
+            }
+        }
+
+        new Fingerprint(
+                sourcePath: versionRoot.toPath().relativize(htmlFile.toPath()).toString().replace('\\', '/'),
+                totalHeadings: metrics.totalHeadings,
+                sectionCount: metrics.sections,
+                totalAnchors: metrics.anchors,
+                codeBlockCount: metrics.codeBlocks,
+                imageCount: metrics.images,
+                headingTree: headingTree,
+                anchorIds: new LinkedHashSet<String>(metrics.anchorIds),
+        )
+    }
+
+    private static void writeFingerprint(File outputFile, Fingerprint fingerprint) {
+        outputFile.parentFile.mkdirs()
+        Map<String, Object> payload = [
+                sourcePath     : fingerprint.sourcePath,
+                totalHeadings  : fingerprint.totalHeadings,
+                sectionCount   : fingerprint.sectionCount,
+                totalAnchors   : fingerprint.totalAnchors,
+                codeBlockCount : fingerprint.codeBlockCount,
+                imageCount     : fingerprint.imageCount,
+                headingTree    : fingerprint.headingTree,
+                anchorIds      : fingerprint.anchorIds as List<String>,
+        ]
+        outputFile.text = JsonOutput.prettyPrint(JsonOutput.toJson(payload)) + '\n'
+    }
+
+    private static File locateRenderedFile(File versionDir) {
+        List<String> candidates = ['guide/single.html', 'guide/index.html', 'index.html']
+        for (String candidate : candidates) {
+            File renderedFile = new File(versionDir, candidate)
+            if (renderedFile.isFile()) {
+                return renderedFile
+            }
+        }
+        null
+    }
+
+    private static File resolveBaselineFile(File baselinesRoot, String guideName, String version) {
+        // TODO: Integrate captured production baseline snapshots from https://guides.grails.org/<guide>/<version>/ once they are committed.
+        if (!baselinesRoot.isDirectory()) {
+            return null
+        }
+        List<String> candidates = [
+                "${guideName}/${version}/guide/single.html".toString(),
+                "${guideName}/${version}/guide/index.html".toString(),
+                "${guideName}/${version}/index.html".toString(),
+        ]
+        for (String candidate : candidates) {
+            File baselineFile = new File(baselinesRoot, candidate)
+            if (baselineFile.isFile()) {
+                return baselineFile
+            }
+        }
+        null
+    }
+
+    private static List<File> sortedDirectories(File root) {
+        File[] children = root.listFiles()
+        List<File> directories = []
+        if (children == null) {
+            return directories
+        }
+        for (File child : children) {
+            if (child.isDirectory()) {
+                directories << child
+            }
+        }
+        directories.sort { File left, File right -> left.name <=> right.name }
+        directories
+    }
+
+    private static void writeCsv(File outputFile, List<GuideSummary> results) {
+        outputFile.parentFile.mkdirs()
+        StringBuilder sb = new StringBuilder('guide,version,status,issueCount,details\n')
+        for (GuideSummary summary : results) {
+            List<String> details = summary.differences.isEmpty()
+                    ? [summary.differencesInfo]
+                    : summary.differences + [summary.differencesInfo]
+            sb << sanitize(summary.guide) << ','
+            sb << sanitize(summary.version) << ','
+            sb << sanitize(summary.status ?: 'VERIFIED') << ','
+            sb << summary.differences.size() << ','
+            sb << sanitize(abbreviate(details.findAll { String value -> value != null && !value.isEmpty() }.join(' | '))) << '\n'
+        }
+        outputFile.text = sb.toString()
+    }
+
+    private static String normalizeText(String value) {
+        (value ?: '').replaceAll(/\s+/, ' ').trim()
+    }
+
+    private static String abbreviate(String value) {
+        if (value.size() <= 1200) {
+            return value
+        }
+        value.substring(0, 1197) + '...'
+    }
+
+    private static String sanitize(String value) {
+        (value ?: '')
+                .replace('\r', ' ')
+                .replace('\n', ' ')
+                .replace(',', ';')
+                .trim()
+    }
+
+    private static boolean isHardFailMode(Project project) {
+        String mode = (project.findProperty('verificationMode') ?: '') as String
+        mode.equalsIgnoreCase('hard-fail')
+    }
+
+    private static final class Fingerprint {
+        String sourcePath
+        int totalHeadings
+        int sectionCount
+        int totalAnchors
+        int codeBlockCount
+        int imageCount
+        List<String> headingTree = []
+        Set<String> anchorIds = [] as LinkedHashSet<String>
+    }
+
+    private static final class GuideSummary {
+        String guide
+        String version
+        String status
+        boolean selfBaseline
+        String differencesInfo = ''
+        List<String> differences = []
+    }
+}

--- a/buildSrc/src/test/groovy/website/gradle/tasks/AcceptanceReportTaskSpec.groovy
+++ b/buildSrc/src/test/groovy/website/gradle/tasks/AcceptanceReportTaskSpec.groovy
@@ -1,0 +1,121 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package website.gradle.tasks
+
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+
+import spock.lang.Specification
+import spock.lang.TempDir
+
+class AcceptanceReportTaskSpec extends Specification {
+
+    @TempDir
+    File tempDir
+
+    def 'combines all gate outputs into a VERIFIED acceptance row'() {
+        given:
+        def project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+        createGuideVersion(project)
+        writeCsv(new File(project.buildDir, 'reports/asciidoctor-warning-gate.csv'), 'demo-guide,1,VERIFIED,0,clean')
+        writeCsv(new File(project.buildDir, 'reports/crawl-built-guides.csv'), 'demo-guide,1,VERIFIED,0,clean')
+        writeCsv(new File(project.buildDir, 'reports/structural-diff-guides.csv'), 'demo-guide,1,VERIFIED,0,clean')
+        new File(project.buildDir, 'reports/csp-scan.md').with {
+            parentFile.mkdirs()
+            text = '# CSP Scan Report\n\n## Result: CLEAN\n'
+        }
+        AcceptanceReportTask.register(project)
+
+        when:
+        def task = project.tasks.getByName(AcceptanceReportTask.NAME) as AcceptanceReportTask
+        task.report()
+
+        then:
+        task.reportFile.get().asFile.text.contains('demo-guide,1,VERIFIED,VERIFIED,VERIFIED,VERIFIED,VERIFIED')
+    }
+
+    def 'writes only the header when there are no guide versions or reports'() {
+        given:
+        def project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+        AcceptanceReportTask.register(project)
+
+        when:
+        def task = project.tasks.getByName(AcceptanceReportTask.NAME) as AcceptanceReportTask
+        task.report()
+
+        then:
+        task.reportFile.get().asFile.readLines() == ['guide,version,asciidoctorWarningGate,crawlBuiltGuides,structuralDiffGuides,cspScan,verdict,details']
+    }
+
+    def 'throws in hard-fail mode when any gate reports FAILED'() {
+        given:
+        def project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+        createGuideVersion(project)
+        writeCsv(new File(project.buildDir, 'reports/asciidoctor-warning-gate.csv'), 'demo-guide,1,FAILED,1,warning found')
+        writeCsv(new File(project.buildDir, 'reports/crawl-built-guides.csv'), 'demo-guide,1,VERIFIED,0,clean')
+        writeCsv(new File(project.buildDir, 'reports/structural-diff-guides.csv'), 'demo-guide,1,VERIFIED,0,clean')
+        new File(project.buildDir, 'reports/csp-scan.md').with {
+            parentFile.mkdirs()
+            text = '# CSP Scan Report\n\n## Result: CLEAN\n'
+        }
+        AcceptanceReportTask.register(project)
+        def task = project.tasks.getByName(AcceptanceReportTask.NAME) as AcceptanceReportTask
+        task.failOnViolation.set(true)
+
+        when:
+        task.report()
+
+        then:
+        def error = thrown(GradleException)
+        error.message.contains('Acceptance report contains FAILED rows')
+        task.reportFile.get().asFile.text.contains('demo-guide,1,FAILED,VERIFIED,VERIFIED,VERIFIED,FAILED')
+    }
+
+    def 'maps guide-specific CSP report entries with windows separators to REVIEW'() {
+        given:
+        def project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+        createGuideVersion(project)
+        writeCsv(new File(project.buildDir, 'reports/asciidoctor-warning-gate.csv'), 'demo-guide,1,VERIFIED,0,clean')
+        writeCsv(new File(project.buildDir, 'reports/crawl-built-guides.csv'), 'demo-guide,1,VERIFIED,0,clean')
+        writeCsv(new File(project.buildDir, 'reports/structural-diff-guides.csv'), 'demo-guide,1,VERIFIED,0,clean')
+        new File(project.buildDir, 'reports/csp-scan.md').with {
+            parentFile.mkdirs()
+            text = '# CSP Scan Report\n\nNon-allowlisted hosts found: 1\n\n## Violations\n\n- `guides\\demo-guide\\1\\guide\\single.html`\n'
+        }
+        AcceptanceReportTask.register(project)
+
+        when:
+        def task = project.tasks.getByName(AcceptanceReportTask.NAME) as AcceptanceReportTask
+        task.report()
+
+        then:
+        task.reportFile.get().asFile.text.contains('demo-guide,1,VERIFIED,VERIFIED,VERIFIED,REVIEW,REVIEW')
+    }
+
+    private void createGuideVersion(def project) {
+        File versionDir = new File(project.buildDir, 'dist/guides/demo-guide/1')
+        versionDir.mkdirs()
+        new File(versionDir, 'index.html').text = '<html></html>'
+    }
+
+    private void writeCsv(File file, String row) {
+        file.parentFile.mkdirs()
+        file.text = 'guide,version,status,issueCount,details\n' + row + '\n'
+    }
+}

--- a/buildSrc/src/test/groovy/website/gradle/tasks/AsciidoctorWarningGateTaskSpec.groovy
+++ b/buildSrc/src/test/groovy/website/gradle/tasks/AsciidoctorWarningGateTaskSpec.groovy
@@ -1,0 +1,93 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package website.gradle.tasks
+
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+
+import grails.doc.gradle.PublishGuideTask
+import spock.lang.Specification
+import spock.lang.TempDir
+
+class AsciidoctorWarningGateTaskSpec extends Specification {
+
+    @TempDir
+    File tempDir
+
+    def 'captures a clean log as VERIFIED and wires cleanup finalizer'() {
+        given:
+        def project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+        String renderTaskName = registerRenderTask(project, 'demo-guide', '1')
+        AsciidoctorWarningGateTask.register(project)
+        File logsDir = new File(project.buildDir, 'logs')
+        logsDir.mkdirs()
+        new File(logsDir, "asciidoctor-${renderTaskName}.log").text = '[INFO] build completed\n'
+
+        when:
+        def gateTask = project.tasks.getByName(AsciidoctorWarningGateTask.NAME) as AsciidoctorWarningGateTask
+        gateTask.gate()
+
+        then:
+        gateTask.group == AsciidoctorWarningGateTask.GROUP
+        gateTask.reportFile.get().asFile.text.contains('demo-guide,1,VERIFIED,0')
+        project.tasks.findByName("cleanup-${renderTaskName}-logs") != null
+    }
+
+    def 'writes only the header when no logs directory exists'() {
+        given:
+        def project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+        AsciidoctorWarningGateTask.register(project)
+
+        when:
+        def gateTask = project.tasks.getByName(AsciidoctorWarningGateTask.NAME) as AsciidoctorWarningGateTask
+        gateTask.gate()
+
+        then:
+        gateTask.reportFile.get().asFile.readLines() == ['guide,version,status,issueCount,details']
+    }
+
+    def 'throws in hard-fail mode when warning lines are detected'() {
+        given:
+        def project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+        String renderTaskName = registerRenderTask(project, 'demo-guide', '1')
+        AsciidoctorWarningGateTask.register(project)
+        File logsDir = new File(project.buildDir, 'logs')
+        logsDir.mkdirs()
+        new File(logsDir, "asciidoctor-${renderTaskName}.log").text = 'asciidoctor: WARNING: missing include target\n'
+        def gateTask = project.tasks.getByName(AsciidoctorWarningGateTask.NAME) as AsciidoctorWarningGateTask
+        gateTask.failOnViolation.set(true)
+
+        when:
+        gateTask.gate()
+
+        then:
+        def error = thrown(GradleException)
+        error.message.contains('AsciiDoctor warnings detected')
+        gateTask.reportFile.get().asFile.text.contains('demo-guide,1,FAILED,1')
+    }
+
+    private String registerRenderTask(def project, String guideName, String version) {
+        project.tasks.register("renderGuide_${guideName}_${version}", PublishGuideTask) { PublishGuideTask task ->
+            task.targetDir.set(project.layout.buildDirectory.dir("dist/guides/${guideName}/${version}"))
+            task.sourceDir.set(project.layout.projectDirectory)
+            task.resourcesDir.set(project.layout.projectDirectory)
+        }
+        "renderGuide_${guideName}_${version}"
+    }
+}

--- a/buildSrc/src/test/groovy/website/gradle/tasks/CrawlBuiltGuidesTaskSpec.groovy
+++ b/buildSrc/src/test/groovy/website/gradle/tasks/CrawlBuiltGuidesTaskSpec.groovy
@@ -1,0 +1,103 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package website.gradle.tasks
+
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+
+import spock.lang.Specification
+import spock.lang.TempDir
+
+class CrawlBuiltGuidesTaskSpec extends Specification {
+
+    @TempDir
+    File tempDir
+
+    def 'marks a guide version VERIFIED when local references resolve'() {
+        given:
+        def project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+        File versionDir = createGuideVersion(project, '''
+<html>
+  <body>
+    <a href="page.html#section">Page</a>
+    <img src="images/logo.png" />
+    <link href="styles/site.css" rel="stylesheet" />
+    <script src="scripts/app.js"></script>
+    <div id="home"></div>
+  </body>
+</html>
+''')
+        new File(versionDir, 'page.html').text = '<html><body><div id="section"></div></body></html>'
+        new File(versionDir, 'images/logo.png').with { parentFile.mkdirs(); text = 'png' }
+        new File(versionDir, 'styles/site.css').with { parentFile.mkdirs(); text = 'body {}' }
+        new File(versionDir, 'scripts/app.js').with { parentFile.mkdirs(); text = 'console.log(1)' }
+        CrawlBuiltGuidesTask.register(project)
+
+        when:
+        def task = project.tasks.getByName(CrawlBuiltGuidesTask.NAME) as CrawlBuiltGuidesTask
+        task.crawl()
+
+        then:
+        task.reportFile.get().asFile.text.contains('demo-guide,1,VERIFIED,0')
+    }
+
+    def 'writes only the header when no guides are rendered yet'() {
+        given:
+        def project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+        CrawlBuiltGuidesTask.register(project)
+
+        when:
+        def task = project.tasks.getByName(CrawlBuiltGuidesTask.NAME) as CrawlBuiltGuidesTask
+        task.crawl()
+
+        then:
+        task.reportFile.get().asFile.readLines() == ['guide,version,status,issueCount,details']
+    }
+
+    def 'throws in hard-fail mode when broken files or anchors are found'() {
+        given:
+        def project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+        createGuideVersion(project, '''
+<html>
+  <body>
+    <a href="#missing-anchor">Broken anchor</a>
+    <img src="images/missing.png" />
+  </body>
+</html>
+''')
+        CrawlBuiltGuidesTask.register(project)
+        def task = project.tasks.getByName(CrawlBuiltGuidesTask.NAME) as CrawlBuiltGuidesTask
+        task.failOnViolation.set(true)
+
+        when:
+        task.crawl()
+
+        then:
+        def error = thrown(GradleException)
+        error.message.contains('Broken rendered guide references detected')
+        task.reportFile.get().asFile.text.contains('demo-guide,1,FAILED,2')
+    }
+
+    private File createGuideVersion(def project, String indexHtml) {
+        File versionDir = new File(project.buildDir, 'dist/guides/demo-guide/1')
+        versionDir.mkdirs()
+        new File(versionDir, 'index.html').text = indexHtml.trim()
+        versionDir
+    }
+}

--- a/buildSrc/src/test/groovy/website/gradle/tasks/StructuralDiffGuidesTaskSpec.groovy
+++ b/buildSrc/src/test/groovy/website/gradle/tasks/StructuralDiffGuidesTaskSpec.groovy
@@ -1,0 +1,94 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package website.gradle.tasks
+
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+
+import spock.lang.Specification
+import spock.lang.TempDir
+
+class StructuralDiffGuidesTaskSpec extends Specification {
+
+    @TempDir
+    File tempDir
+
+    def 'extracts a structural fingerprint and marks the guide REVIEW until a production baseline exists'() {
+        given:
+        def project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+        createStructuralFile(project, '''
+<html>
+  <body>
+    <h1 id="intro">Intro</h1>
+    <div class="sect1">
+      <h2 id="details">Details</h2>
+      <pre>code</pre>
+      <img src="img.png" />
+    </div>
+  </body>
+</html>
+''')
+        StructuralDiffGuidesTask.register(project)
+
+        when:
+        def task = project.tasks.getByName(StructuralDiffGuidesTask.NAME) as StructuralDiffGuidesTask
+        task.diff()
+
+        then:
+        task.reportFile.get().asFile.text.contains('demo-guide,1,REVIEW,0')
+        new File(project.buildDir, 'reports/structural-fingerprints/demo-guide/1.json').text.contains('Intro')
+    }
+
+    def 'writes only the header when no rendered guides exist'() {
+        given:
+        def project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+        StructuralDiffGuidesTask.register(project)
+
+        when:
+        def task = project.tasks.getByName(StructuralDiffGuidesTask.NAME) as StructuralDiffGuidesTask
+        task.diff()
+
+        then:
+        task.reportFile.get().asFile.readLines() == ['guide,version,status,issueCount,details']
+    }
+
+    def 'throws in hard-fail mode when the rendered file has no headings'() {
+        given:
+        def project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+        createStructuralFile(project, '<html><body><div id="only-anchor"></div></body></html>')
+        StructuralDiffGuidesTask.register(project)
+        def task = project.tasks.getByName(StructuralDiffGuidesTask.NAME) as StructuralDiffGuidesTask
+        task.failOnViolation.set(true)
+
+        when:
+        task.diff()
+
+        then:
+        def error = thrown(GradleException)
+        error.message.contains('Structural guide differences detected')
+        task.reportFile.get().asFile.text.contains('demo-guide,1,FAILED,1')
+    }
+
+    private File createStructuralFile(def project, String html) {
+        File file = new File(project.buildDir, 'dist/guides/demo-guide/1/guide/single.html')
+        file.parentFile.mkdirs()
+        file.text = html.trim()
+        file
+    }
+}


### PR DESCRIPTION
## Summary

Adds the verification harness for rendered guides as 5 new Gradle tasks plus an aggregate `verifyAllGuides` runner. Defaults to report-only mode; `-PverificationMode=hard-fail` switches to fail-on-violation.

## Tasks added

| Task | Group | Purpose |
|---|---|---|
| `asciidoctorWarningGate` | Migration tasks | Captures stdout/stderr from each `PublishGuide` task to `build/logs/asciidoctor-*.log` and matches against the canonical warning regex (`[WARNING]`, `[ERROR]`, `asciidoctor: WARN/ERROR/FAIL`, JVM exception/stack traces, `Caused by:`) with an explicit allowlist hook. |
| `crawlBuiltGuides` | Migration tasks | Walks rendered `build/dist/guides/<name>/<v>/*.html` for broken local `<a>`/`<img>`/`<link>`/`<script>` refs and missing in-document anchors. Jsoup-driven; ignores external https URLs (those are handled by `cspScan`). |
| `structuralDiffGuides` | Migration tasks | Extracts heading-tree + anchor-id + per-element counts as a fingerprint per (guide, version). Compares against captured baselines if present. **Production-baseline integration is a follow-up** -- this PR ships the extractor and the comparison harness, marked REVIEW in the acceptance report until the legacy `guides.grails.org` snapshot is wired in. |
| `acceptanceReport` | Migration tasks | Reads each gate's CSV and writes `build/reports/acceptance.csv` with one row per (guide, version) and a per-component verdict (VERIFIED / REVIEW / FAILED). |
| `verifyAllGuides` | Migration tasks | Aggregate. Depends on `buildAllGuides`, `asciidoctorWarningGate`, `crawlBuiltGuides`, `structuralDiffGuides`, `cspScan`, `acceptanceReport`. Default mode is report-only (exit 0); `-PverificationMode=hard-fail` flips it. |

## Existing infrastructure reused

- `cspScan` (existing) is wired as the 11e gate; `CspScanTask` group changed from `documentation` to `migration` so it shows up alongside the rest.
- `AdHocFixtureDiff` (Phase 8) extends with the structural-fingerprint extraction primitives.
- `RenderGuidesPlugin` and `GrailsWebsitePlugin` get the wiring hooks.

## Output locations

- `build/logs/asciidoctor-*.log` -- per-task captured output
- `build/reports/asciidoctor-warning-gate.csv` -- per-(guide, version) warning verdict
- `build/reports/crawl-built-guides.csv` -- per-(guide, version) crawl verdict
- `build/reports/structural-diff-guides.csv` -- per-(guide, version) structural-fingerprint verdict
- `build/reports/csp-scan.md` -- existing CSP scan output (unchanged)
- `build/reports/acceptance.csv` -- combined per-(guide, version) verdict across all gates

## Tests

Each new task has a Spock spec covering happy path, empty-input, and failure detection. `./gradlew :buildSrc:test` passes.

## Behavior verified locally

- `./gradlew tasks --group=migration` lists all 5 new tasks plus existing `cspScan`, `publishMainSite`, `validateGuides`, `buildAllGuides`, `vendor*`, `renderGuide_*`.
- `./gradlew :buildSrc:compileGroovy :buildSrc:compileTestGroovy :buildSrc:test` -- BUILD SUCCESSFUL.

## Out of scope (follow-ups)

- Production-baseline integration for `structuralDiffGuides` (capture `https://guides.grails.org/<g>/<v>/` snapshots and commit). All structural rows currently land as REVIEW pending that capture.
- Visual diff (Playwright). Plan keeps this advisory-only; not implemented here.
- Hard-fail mode allowlist tuning. Initial run will surface real findings; allowlist additions get owner approval per Appendix A policy.

Refs #354.