### PR TITLE
Cut over to grails.apache.org/guides as the canonical guide location (refs #354)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,8 +53,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GRAILS_GHTOKEN }}
           GH_BRANCH: asf-site-production
           GRAILS_WS_URL: https://grails.apache.org
-      # NOTE: A previous "Publish Guides Site" step that pushed to
-      # grails-guides/grails-guides-template gh-pages was removed as part
-      # of issue #354. https://guides.grails.org/ is served from that
-      # frozen gh-pages branch until the new canonical location at
-      # https://grails.apache.org/guides/ is fully cut over.
+      # The publishMainSite Gradle task depends on both `build` and
+      # `buildAllGuides`, so the rendered guide corpus under
+      # build/dist/guides/<name>/<v>/ is mirrored into the deploy repo as
+      # part of the same step, making https://grails.apache.org/guides/
+      # the canonical guide location served by apache/grails-website.
+      # https://guides.grails.org/ remains alive serving frozen content
+      # from grails-guides/grails-guides-template gh-pages until Phase 15
+      # of issue #354 swaps it for redirect stubs.

--- a/buildSrc/src/main/groovy/website/gradle/tasks/GuidesTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/GuidesTask.groovy
@@ -110,7 +110,10 @@ abstract class GuidesTask extends GrailsWebsiteTask {
 
         def template = document.get().asFile
         def templateText = template.text
-        def distDir = outputDir.dir('dist').get().asFile.tap { it.mkdirs() }
+        // Guides landing, tag pages, and category pages live under /guides/ so they
+        // line up with https://grails.apache.org/guides/{index,tags,categories}.html.
+        // The main site index.html (rendered by RenderSiteTask) keeps build/dist/index.html.
+        def distDir = outputDir.dir('dist/guides').get().asFile.tap { it.mkdirs() }
 
         def releasesFile = releases.get().asFile
         def latest = SiteMap.latestVersion(releasesFile)

--- a/buildSrc/src/main/groovy/website/gradle/tasks/PublishMainSiteTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/PublishMainSiteTask.groovy
@@ -159,6 +159,9 @@ abstract class PublishMainSiteTask extends DefaultTask {
     static TaskProvider<PublishMainSiteTask> register(Project project) {
         project.tasks.register(NAME, PublishMainSiteTask) { PublishMainSiteTask task ->
             task.dependsOn('build')
+            // Also include the vendored guide corpus so build/dist/guides/<name>/<v>/
+            // ships alongside the main site under https://grails.apache.org/guides/.
+            task.dependsOn('buildAllGuides')
             task.gitHubSlug.convention(
                     project.providers.environmentVariable('GITHUB_SLUG')
                             .orElse(DEFAULT_GITHUB_SLUG))

--- a/buildSrc/src/main/groovy/website/model/guides/GuidesFetcher.groovy
+++ b/buildSrc/src/main/groovy/website/model/guides/GuidesFetcher.groovy
@@ -166,7 +166,7 @@ class GuidesFetcher {
                 String pubDate = (version.publicationDate ?: guide.publicationDate) as String
 
                 result << new GuideDto(
-                        grailsVersion: null,
+                        grailsVersion: versionKeyObj as String,
                         authors: authors,
                         category: category,
                         githubSlug: slug,

--- a/buildSrc/src/main/groovy/website/model/guides/GuidesPage.groovy
+++ b/buildSrc/src/main/groovy/website/model/guides/GuidesPage.groovy
@@ -59,7 +59,7 @@ class GuidesPage {
                 if (guide instanceof SingleGuide) {
                     a(
                             class: (guide.tags.contains('quick-cast') ? 'quick-cast guide' : 'guide'),
-                            href: "$GUIDES_URL/$guide.name/guide/index.html", guide.title
+                            href: "$GUIDES_URL/${guide.name}/${guide.versionNumber}/guide/index.html", guide.title
                     )
                     guide.tags.each {
                         span(
@@ -76,7 +76,7 @@ class GuidesPage {
                             div(class: 'align-left') {
                                 a(
                                         class: 'grails-version',
-                                        href: "$GUIDES_URL/grails$grailsVersion/${multiGuide.githubSlug.replace('grails-guides', '')}/guide/index.html"
+                                        href: "$GUIDES_URL/${multiGuide.name}/${grailsVersion}/guide/index.html"
                                 ) {
                                     mkp.yield("grails$grailsVersion")
                                 }
@@ -247,7 +247,7 @@ class GuidesPage {
                                         mkp.yield(' - ')
                                         mkp.yield(guide.category)
                                     }
-                                    a(href: "$GUIDES_URL/$guide.name/guide/index.html", 'Read More')
+                                    a(href: "$GUIDES_URL/${guide.name}/${guide.versionNumber}/guide/index.html", 'Read More')
                                 }
                             }
                 }

--- a/buildSrc/src/main/groovy/website/model/guides/GuidesPage.groovy
+++ b/buildSrc/src/main/groovy/website/model/guides/GuidesPage.groovy
@@ -32,7 +32,7 @@ import static website.utils.RenderUtils.renderHtml
 class GuidesPage {
 
     public static final Integer NUMBER_OF_LATEST_GUIDES = 8
-    public static final String GUIDES_URL = 'https://guides.grails.org'
+    public static final String GUIDES_URL = 'https://grails.apache.org/guides'
 
     static Map<String, Category> categories = [
             advanced: new Category(name: 'Advanced Grails', image: 'advancedgrails.svg'),


### PR DESCRIPTION
## Summary

Cuts `apache/grails-static-website` over to publish the rendered guide corpus under `https://grails.apache.org/guides/` as part of the unified main-site deploy. Two small commits, no operational scripts changed (per Gradle-only directive). Refs #354.

## Changes

### 12a - URL canonicalization

`GuidesPage.GUIDES_URL` switches from `https://guides.grails.org` to `https://grails.apache.org/guides`. Index, tag, and category pages now link to the new canonical location.

### 12b - Unified publish step

`PublishMainSiteTask` now also depends on `buildAllGuides`, so the rendered guide corpus under `build/dist/guides/<name>/<v>/` is included in the same mirror push to `apache/grails-website asf-site-production`. `publish.yml` documents the new shape.

## Cutover behavior

After merge, the next `publish.yml` run does:

1. `./gradlew clean publishMainSite` builds the main site PLUS the rendered guide corpus into `build/dist/`.
2. The mirror step pushes to `apache/grails-website asf-site-production`.
3. Once ASF infra picks up the deploy (typically 5-15 min), `https://grails.apache.org/guides/` becomes canonical.

## What stays unchanged

- `https://guides.grails.org` continues serving frozen content from the `grails-guides/grails-guides-template gh-pages` branch (not yet redirected). Phase 15 will deploy meta-refresh stubs to it.
- No URL changes in vendored test fixtures or parity-baseline snapshots (those reference the legacy site intentionally for parity comparison against the captured baseline).

## Out of scope (deferred)

- **Phase 12d redirect manifest generation** is deferred to Phase 15 (where it is consumed). The plan originally placed 12d in Phase 12 to unblock Phase 13's live URL crawl, but Phase 13 (production soak) was skipped per owner directive, so 12d is best done immediately before Phase 15 needs it. Generating it requires committing the ~1.3 MB freeze-baseline path manifest into the public tree, which is an irreversible local-data publication better tied to the Phase 15 PR.
- `runLiveCspCheck` Gradle task (Phase 12 QA scenario step 5) - separate small follow-up if desired; the existing `cspScan` already covers offline scanning of `build/dist/` HTML.

## Verification

- `./gradlew :buildSrc:compileGroovy :buildSrc:test` passes locally.
- `./gradlew tasks --group=migration` lists `publishMainSite` and `buildAllGuides` correctly wired.
- After this merges, the first `publish.yml` run is the live cutover; new URLs should respond 200 within 5-15 min of completion. The legacy `https://guides.grails.org` URLs continue to respond 200 with frozen content.