### PR TITLE
Hotfix: drop log-cleanup finalizer to unblock publishMainSite (refs #354)

### DIFF
--- a/buildSrc/src/main/groovy/website/gradle/tasks/AsciidoctorWarningGateTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/AsciidoctorWarningGateTask.groovy
@@ -23,10 +23,8 @@ import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.plugins.ExtraPropertiesExtension
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.Input
@@ -143,7 +141,15 @@ class AsciidoctorWarningGateTask extends DefaultTask {
     }
 
     private static void wireLogCapture(Project project) {
-        project.tasks.withType(PublishGuideTask).all { PublishGuideTask renderTask ->
+        // The listener is added in doFirst on each PublishGuide task. We deliberately
+        // do NOT register a finalizer cleanup task: removing the listener would
+        // require the cleanup task to access the renderTask's extensions/logging at
+        // execution time, which Gradle's configuration cache disallows when the
+        // cleanup is wired across tasks. Leaving the listener attached for the
+        // remainder of the JVM lifetime is harmless: each `gradle` invocation runs
+        // in a single-use Daemon (see publish.yml: --no-daemon) so the listener is
+        // GC'd when the process exits, never crossing build boundaries.
+        project.tasks.withType(PublishGuideTask).configureEach { PublishGuideTask renderTask ->
             File logsRoot = project.layout.buildDirectory.dir('logs').get().asFile
             File logFile = new File(logsRoot, "asciidoctor-${renderTask.name}.log")
 
@@ -157,31 +163,7 @@ class AsciidoctorWarningGateTask extends DefaultTask {
 
                 renderTask.logging.addStandardOutputListener(writeListener)
                 renderTask.logging.addStandardErrorListener(writeListener)
-
-                ExtraPropertiesExtension extraProperties = renderTask.extensions.extraProperties
-                extraProperties.set('logFile', logFile)
-                extraProperties.set('logListener', writeListener)
             }
-
-            String cleanupTaskName = "cleanup-${renderTask.name}-logs"
-            if (project.tasks.findByName(cleanupTaskName) == null) {
-                project.tasks.register(cleanupTaskName) { Task cleanupTask ->
-                    cleanupTask.notCompatibleWithConfigurationCache('Removes StandardOutputListener instances from PublishGuide tasks.')
-                    cleanupTask.doLast {
-                        try {
-                            ExtraPropertiesExtension extraProperties = renderTask.extensions.extraProperties
-                            if (extraProperties.has('logListener')) {
-                                StandardOutputListener writeListener = extraProperties.get('logListener') as StandardOutputListener
-                                renderTask.logging.removeStandardOutputListener(writeListener)
-                                renderTask.logging.removeStandardErrorListener(writeListener)
-                            }
-                        } catch (Exception e) {
-                            project.logger.warn("Listener cleanup failed for ${renderTask.name}: ${e.message}")
-                        }
-                    }
-                }
-            }
-            renderTask.finalizedBy(cleanupTaskName)
         }
     }
 

--- a/buildSrc/src/test/groovy/website/gradle/tasks/AsciidoctorWarningGateTaskSpec.groovy
+++ b/buildSrc/src/test/groovy/website/gradle/tasks/AsciidoctorWarningGateTaskSpec.groovy
@@ -30,7 +30,7 @@ class AsciidoctorWarningGateTaskSpec extends Specification {
     @TempDir
     File tempDir
 
-    def 'captures a clean log as VERIFIED and wires cleanup finalizer'() {
+    def 'captures a clean log as VERIFIED'() {
         given:
         def project = ProjectBuilder.builder().withProjectDir(tempDir).build()
         String renderTaskName = registerRenderTask(project, 'demo-guide', '1')
@@ -46,7 +46,6 @@ class AsciidoctorWarningGateTaskSpec extends Specification {
         then:
         gateTask.group == AsciidoctorWarningGateTask.GROUP
         gateTask.reportFile.get().asFile.text.contains('demo-guide,1,VERIFIED,0')
-        project.tasks.findByName("cleanup-${renderTaskName}-logs") != null
     }
 
     def 'writes only the header when no logs directory exists'() {


### PR DESCRIPTION
## Summary

Hotfix for the publishMainSite failure on the PR #458 cutover deploy ([run 25221748574](https://github.com/apache/grails-static-website/actions/runs/25221748574)). The build hit 2902 configuration-cache violations in the form:

> Plugin 'grails-website': execution of task ':cleanup-renderGuide_<name>_<v>-logs' caused invocation of 'Task.extensions' in other task at execution time which is unsupported with the configuration cache.

## Root cause

PR #457 wired `AsciidoctorWarningGateTask.wireLogCapture` to register, for every `PublishGuide` task, a finalizer `cleanup-<name>-logs` that removed the standard-output listener after rendering. The finalizer reached into `renderTask.extensions.extraProperties` and `renderTask.logging` at execution time. Gradle's configuration cache forbids cross-task access at execution time, even when the finalizer itself is marked `notCompatibleWithConfigurationCache`.

The PR #457 deploy itself happened to succeed because it ran main-site tasks only and never instantiated any `renderGuide_*` task. PR #458's `publishMainSite -> buildAllGuides` wiring was the first deploy to actually pull in the `renderGuide_*` tasks under publishMainSite, exposing the latent violation.

## Fix

Drop the cleanup finalizer entirely. The `doFirst` listener-attach in `wireLogCapture` stays - that's safe because it accesses `this`-scoped task state. Removing the listener at task end is unnecessary in practice: the publish runs use `--no-daemon` (see publish.yml), so the JVM exits at build-end and reclaims the listener via process termination. There is no listener leak across builds.

## Verification

- `./gradlew :buildSrc:compileGroovy :buildSrc:test --console=plain --no-daemon` - PASS
- `AsciidoctorWarningGateTaskSpec` updated to drop the now-removed `cleanup-*` task assertion
- All other Phase 11 specs (CrawlBuiltGuides, StructuralDiff, AcceptanceReport) untouched

## Out of scope

The same publish run also surfaced implicit-dependency warnings between `renderGuide_*` and main-site tasks (`genPlugins`, `renderBlog`, etc.) that share `build/` as a coarse output dir. Those are validation warnings, not the failure cause; tracking as a separate cleanup if they cause issues post-cutover.

Refs #354.