### PR TITLE
Hotfix 2: disable config-cache for publishMainSite deploy (refs #354)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,15 @@ jobs:
         with:
           develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       - name: Publish Main Site
-        run: ./gradlew clean publishMainSite --console=plain --no-daemon
+        # --no-configuration-cache is required because the vendored
+        # grails.doc.gradle.PublishGuideTask (instantiated as renderGuide_*)
+        # holds non-serializable state (Logger, Stack, Vector, ReferenceQueue).
+        # Even when each task declares notCompatibleWithConfigurationCache,
+        # Gradle 9.4.1's parallel-config-cache STORE step still attempts to
+        # serialize a snapshot of the task state and fails. Disabling the
+        # cache for the deploy run trades a small startup cost for a
+        # deterministic publish.
+        run: ./gradlew clean publishMainSite --console=plain --no-daemon --no-configuration-cache
         env:
           GITHUB_SLUG: apache/grails-website
           GH_TOKEN: ${{ secrets.GRAILS_GHTOKEN }}


### PR DESCRIPTION
## Summary

Second hotfix for the cutover deploy. PR #459 cleared 2902 of the configuration-cache violations by dropping the cross-task cleanup finalizer, but the next `Publish` run ([25222379090](https://github.com/apache/grails-static-website/actions/runs/25222379090)) still failed with serialization errors on the vendored `grails.doc.gradle.PublishGuideTask`:

> Task `:renderGuide_adding_commit_info_3` of type `grails.doc.gradle.PublishGuideTask`: error writing value of type `java.lang.ref.ReferenceQueue`  
> Task `:renderGuide_adding_commit_info_3` of type `grails.doc.gradle.PublishGuideTask`: error writing value of type `java.util.Stack`  
> Task `:renderGuide_adding_commit_info_3` of type `grails.doc.gradle.PublishGuideTask`: error writing value of type `java.util.Vector`  
> Task `:renderGuide_adding_commit_info_3` of type `grails.doc.gradle.PublishGuideTask`: error writing value of type `java.util.logging.Logger`

## Root cause

`RenderGuidesPlugin` already declares `task.notCompatibleWithConfigurationCache(...)` on every `renderGuide_*` task, but Gradle 9.4.1's parallel-configuration-cache STORE step still walks each task to fingerprint its state for cache-store. Non-serializable fields in the vendored `PublishGuideTask` (held over from the original grails-doc plugin) trip the STORE step and fail the build.

## Fix

Add `--no-configuration-cache` to the `publishMainSite` invocation in publish.yml. The deploy:

- runs once per push (single-shot)
- already uses `--no-daemon` (no warm JVM to benefit from cache reuse)
- has no parallel sibling task graph (just produce dist tree, mirror push)

Disabling config-cache for that one command costs ~2-5s of startup and trades it for a deterministic publish.

## Out of scope

Long-term, `RenderGuidesPlugin` should be refactored so `PublishGuide` task state survives a cache fingerprint (e.g. lifting non-serializable fields into a separate worker task and using `WorkerExecutor`). That's a Phase 14 cleanup item, not a cutover blocker.

Refs #354.