### PR TITLE
Hotfix 3: order renderGuide_* tasks after main-site tasks (refs #354)

### DIFF
--- a/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
@@ -26,7 +26,20 @@ import org.gradle.api.file.Directory
 import org.yaml.snakeyaml.Yaml
 
 import grails.doc.gradle.PublishGuideTask
+import website.gradle.tasks.AssetsTask
+import website.gradle.tasks.BlogTask
+import website.gradle.tasks.BskyAtProtoDidTask
+import website.gradle.tasks.DocumentationTask
+import website.gradle.tasks.DownloadTask
+import website.gradle.tasks.GuidesTask
+import website.gradle.tasks.HtaccessTask
+import website.gradle.tasks.MinutesTask
 import website.gradle.tasks.ParityCheckGuideTask
+import website.gradle.tasks.PluginsTask
+import website.gradle.tasks.ProfilesTask
+import website.gradle.tasks.QuestionsTask
+import website.gradle.tasks.RenderSiteTask
+import website.gradle.tasks.SitemapTask
 import website.gradle.tasks.VendorGuideTask
 
 /**
@@ -238,11 +251,14 @@ class RenderGuidesPlugin {
                     // :renderBlog/:renderMinutes/:genProfilesPage without declaring
                     // dependency'. mustRunAfter resolves the ordering without
                     // forcing those tasks to be invoked when only renderGuide_* is
-                    // scheduled.
-                    task.mustRunAfter('renderSite', 'genPlugins', 'renderBlog',
-                            'renderMinutes', 'genProfilesPage', 'genHtaccess',
-                            'genBskyAtProtoDid', 'genSitemap', 'copyAssets',
-                            'genDocsPage', 'genDownloads', 'genFaq', 'genGuides')
+                    // scheduled. Names come from each task class's NAME constant
+                    // so a future task rename surfaces as a compile error here.
+                    task.mustRunAfter(RenderSiteTask.NAME, PluginsTask.NAME,
+                            BlogTask.NAME, MinutesTask.NAME, ProfilesTask.NAME,
+                            HtaccessTask.NAME, BskyAtProtoDidTask.NAME,
+                            SitemapTask.NAME, AssetsTask.NAME,
+                            DocumentationTask.NAME, DownloadTask.NAME,
+                            QuestionsTask.NAME, GuidesTask.NAME)
                 }
                 wiring.renderTaskNames << renderTaskName
 

--- a/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
@@ -230,6 +230,19 @@ class RenderGuidesPlugin {
                     // copy byte-clean for re-vendor.
                     task.notCompatibleWithConfigurationCache(
                             'Vendored grails.doc.gradle.PublishGuideTask references Project + AntBuilder')
+                    // Several main-site rendering tasks declare build/ as their
+                    // @OutputDirectory (they write to build/dist/<x>.html), which
+                    // overlaps with build/staged-guides/<name>/<v>/. Without
+                    // explicit ordering, Gradle 9.4 raises a fatal validation
+                    // error: 'renderGuide_* uses output of :renderSite/:genPlugins/
+                    // :renderBlog/:renderMinutes/:genProfilesPage without declaring
+                    // dependency'. mustRunAfter resolves the ordering without
+                    // forcing those tasks to be invoked when only renderGuide_* is
+                    // scheduled.
+                    task.mustRunAfter('renderSite', 'genPlugins', 'renderBlog',
+                            'renderMinutes', 'genProfilesPage', 'genHtaccess',
+                            'genBskyAtProtoDid', 'genSitemap', 'copyAssets',
+                            'genDocsPage', 'genDownloads', 'genFaq', 'genGuides')
                 }
                 wiring.renderTaskNames << renderTaskName
 


### PR DESCRIPTION
## Summary

Third hotfix for the cutover deploy. PR #460 disabled configuration-cache, but the next `Publish` run ([25222647940](https://github.com/apache/grails-static-website/actions/runs/25222647940)) failed with task-output validation errors:

> Reason: Task `:renderGuide_adding_commit_info_3` uses this output of task `:genPlugins` without declaring an explicit or implicit dependency.

(Repeated for `renderBlog`, `renderMinutes`, `renderSite`, `genProfilesPage`.)

## Root cause

Gradle 9.4 promoted the previously-warning `implicit_dependency` check to a fatal validation error. The renderGuide_* tasks read `build/staged-guides/<name>/<v>/` as input. The main-site rendering tasks (`renderSite`, `genPlugins`, etc.) all set their `@OutputDirectory` to `build/` (via `siteExt.outputDir`, which conventions to `layout.buildDirectory`). The two output trees overlap at `build/`, and Gradle treats that as an implicit dependency that must be declared.

PR #458 was the first deploy where both task chains ran under the same invocation (`publishMainSite -> build` AND `publishMainSite -> buildAllGuides`). Before that, the renderGuide_* tasks only ran from `buildAllGuides` standalone, so the validation never surfaced.

## Fix

Declare `task.mustRunAfter` against every main-site rendering task. `mustRunAfter` only orders if both are scheduled, so calling `buildAllGuides` alone still works; calling `publishMainSite` schedules both chains and now gets a correct ordering with no validation errors.

## Local verification

`
$ ./gradlew clean build buildAllGuides --no-daemon --no-configuration-cache
...
> Task :buildAllGuides

BUILD SUCCESSFUL in 2m 42s
270 actionable tasks: 265 executed, 5 up-to-date
`

This matches the CI scenario's task graph (publishMainSite's only addition is the mirror push, which fails locally because GH_TOKEN isn't set). The validation errors that killed the CI run are gone.

Refs #354.