### PR TITLE
Hotfix 4: wire buildGuides into publishMainSite (refs #354)

### DIFF
--- a/buildSrc/src/main/groovy/website/gradle/tasks/PublishMainSiteTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/PublishMainSiteTask.groovy
@@ -159,6 +159,14 @@ abstract class PublishMainSiteTask extends DefaultTask {
     static TaskProvider<PublishMainSiteTask> register(Project project) {
         project.tasks.register(NAME, PublishMainSiteTask) { PublishMainSiteTask task ->
             task.dependsOn('build')
+            // The legacy `buildGuides` aggregate runs GuidesTask, which writes
+            // build/dist/guides/{index.html,tags/,categories/}. It used to be
+            // pushed by a separate "Publish Guides Site" step targeting
+            // guides.grails.org gh-pages. That step was removed in issue #354
+            // and the corresponding deploy edge dropped. Re-add it here so the
+            // guides landing, tag, and category pages ship into
+            // apache/grails-website asf-site-production alongside the main site.
+            task.dependsOn('buildGuides')
             // Also include the vendored guide corpus so build/dist/guides/<name>/<v>/
             // ships alongside the main site under https://grails.apache.org/guides/.
             task.dependsOn('buildAllGuides')


### PR DESCRIPTION
## Summary

Fourth and final hotfix for the cutover deploy. The first three (PRs #459-461) cleared progressive build-failure modes; this one fixes the silent omission that explains why `https://grails.apache.org/guides/index.html` is still 404 even though the deploy run for #461 reported success.

## Root cause

The publish run for #461 deployed only the per-guide HTML (`build/dist/guides/<name>/<v>/...`) but not the guides landing/tags/categories pages. Inspection of the deploy run task list confirms `genGuides` was never executed:

> Tasks executed: copyAssets, genDocsPage, genDownloads, genFaq, genProfilesPage, renderSite, renderMinutes, renderBlog, genBskyAtProtoDid, genHtaccess, genPlugins, genSitemap, build, stageGuideSource_*, renderGuide_*

`GuidesTask` (registered as `genGuides`) is wired only into the legacy `buildGuides` aggregate. `buildGuides` used to be published by a separate `Publish Guides Site` step targeting `guides.grails.org` gh-pages, which was removed in issue #354. PR #458 added `publishMainSite -> buildAllGuides` (for vendored guide corpus) but missed re-wiring `buildGuides` (for the index/tags/categories), so those three pages stopped being generated entirely on the deploy path.

## Fix

Add `task.dependsOn('buildGuides')` to `PublishMainSiteTask.register`. This pulls `GuidesTask` back into the deploy task graph.

## Local verification

`
$ ./gradlew clean build buildGuides buildAllGuides --no-daemon --no-configuration-cache
> Task :genGuides
> Task :buildGuides
> Task :buildAllGuides
BUILD SUCCESSFUL

$ Test-Path build/dist/guides/index.html
True
$ Test-Path build/dist/guides/tags
True
$ Test-Path build/dist/guides/categories
True
`

After this merges, the next `publish.yml` run should deploy those three artifacts and the cutover URLs will respond 200.

Refs #354.