### PR TITLE
Restore additive mirror semantic in publishMainSite (refs #354)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,25 +47,11 @@ jobs:
         with:
           develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       - name: Publish Main Site
-        # --no-configuration-cache is required because the vendored
-        # grails.doc.gradle.PublishGuideTask (instantiated as renderGuide_*)
-        # holds non-serializable state (Logger, Stack, Vector, ReferenceQueue).
-        # Even when each task declares notCompatibleWithConfigurationCache,
-        # Gradle 9.4.1's parallel-config-cache STORE step still attempts to
-        # serialize a snapshot of the task state and fails. Disabling the
-        # cache for the deploy run trades a small startup cost for a
-        # deterministic publish.
+        # The vendored PublishGuideTask is not configuration-cache safe.
         run: ./gradlew clean publishMainSite --console=plain --no-daemon --no-configuration-cache
         env:
           GITHUB_SLUG: apache/grails-website
           GH_TOKEN: ${{ secrets.GRAILS_GHTOKEN }}
           GH_BRANCH: asf-site-production
           GRAILS_WS_URL: https://grails.apache.org
-      # The publishMainSite Gradle task depends on both `build` and
-      # `buildAllGuides`, so the rendered guide corpus under
-      # build/dist/guides/<name>/<v>/ is mirrored into the deploy repo as
-      # part of the same step, making https://grails.apache.org/guides/
-      # the canonical guide location served by apache/grails-website.
-      # https://guides.grails.org/ remains alive serving frozen content
-      # from grails-guides/grails-guides-template gh-pages until Phase 15
-      # of issue #354 swaps it for redirect stubs.
+

--- a/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
@@ -236,23 +236,9 @@ class RenderGuidesPlugin {
                                     "dist/guides/${guideName}/${versionKey}"))
                     task.asciidoc.set(true)
                     task.properties.set(attributes)
-                    // The vendored PublishGuideTask holds a Project reference
-                    // and an AntBuilder, neither of which serialize for
-                    // Gradle's configuration cache. Annotating here (instead
-                    // of editing the vendored source) keeps the upstream
-                    // copy byte-clean for re-vendor.
                     task.notCompatibleWithConfigurationCache(
                             'Vendored grails.doc.gradle.PublishGuideTask references Project + AntBuilder')
-                    // Several main-site rendering tasks declare build/ as their
-                    // @OutputDirectory (they write to build/dist/<x>.html), which
-                    // overlaps with build/staged-guides/<name>/<v>/. Without
-                    // explicit ordering, Gradle 9.4 raises a fatal validation
-                    // error: 'renderGuide_* uses output of :renderSite/:genPlugins/
-                    // :renderBlog/:renderMinutes/:genProfilesPage without declaring
-                    // dependency'. mustRunAfter resolves the ordering without
-                    // forcing those tasks to be invoked when only renderGuide_* is
-                    // scheduled. Names come from each task class's NAME constant
-                    // so a future task rename surfaces as a compile error here.
+                    // Order after the main-site tasks since they share build/ as @OutputDirectory.
                     task.mustRunAfter(RenderSiteTask.NAME, PluginsTask.NAME,
                             BlogTask.NAME, MinutesTask.NAME, ProfilesTask.NAME,
                             HtaccessTask.NAME, BskyAtProtoDidTask.NAME,

--- a/buildSrc/src/main/groovy/website/gradle/tasks/AsciidoctorWarningGateTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/AsciidoctorWarningGateTask.groovy
@@ -141,14 +141,9 @@ class AsciidoctorWarningGateTask extends DefaultTask {
     }
 
     private static void wireLogCapture(Project project) {
-        // The listener is added in doFirst on each PublishGuide task. We deliberately
-        // do NOT register a finalizer cleanup task: removing the listener would
-        // require the cleanup task to access the renderTask's extensions/logging at
-        // execution time, which Gradle's configuration cache disallows when the
-        // cleanup is wired across tasks. Leaving the listener attached for the
-        // remainder of the JVM lifetime is harmless: each `gradle` invocation runs
-        // in a single-use Daemon (see publish.yml: --no-daemon) so the listener is
-        // GC'd when the process exits, never crossing build boundaries.
+        // Attach a per-task output listener that mirrors render output to a
+        // log file under build/logs/. The listener is GC'd at JVM exit, so
+        // no cross-task finalizer cleanup is required.
         project.tasks.withType(PublishGuideTask).configureEach { PublishGuideTask renderTask ->
             File logsRoot = project.layout.buildDirectory.dir('logs').get().asFile
             File logFile = new File(logsRoot, "asciidoctor-${renderTask.name}.log")

--- a/buildSrc/src/main/groovy/website/gradle/tasks/GuidesTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/GuidesTask.groovy
@@ -110,9 +110,7 @@ abstract class GuidesTask extends GrailsWebsiteTask {
 
         def template = document.get().asFile
         def templateText = template.text
-        // Guides landing, tag pages, and category pages live under /guides/ so they
-        // line up with https://grails.apache.org/guides/{index,tags,categories}.html.
-        // The main site index.html (rendered by RenderSiteTask) keeps build/dist/index.html.
+        // Guides landing, tag, and category pages live under /guides/.
         def distDir = outputDir.dir('dist/guides').get().asFile.tap { it.mkdirs() }
 
         def releasesFile = releases.get().asFile

--- a/buildSrc/src/main/groovy/website/gradle/tasks/PublishMainSiteTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/PublishMainSiteTask.groovy
@@ -159,16 +159,9 @@ abstract class PublishMainSiteTask extends DefaultTask {
     static TaskProvider<PublishMainSiteTask> register(Project project) {
         project.tasks.register(NAME, PublishMainSiteTask) { PublishMainSiteTask task ->
             task.dependsOn('build')
-            // The legacy `buildGuides` aggregate runs GuidesTask, which writes
-            // build/dist/guides/{index.html,tags/,categories/}. It used to be
-            // pushed by a separate "Publish Guides Site" step targeting
-            // guides.grails.org gh-pages. That step was removed in issue #354
-            // and the corresponding deploy edge dropped. Re-add it here so the
-            // guides landing, tag, and category pages ship into
-            // apache/grails-website asf-site-production alongside the main site.
+            // Guides landing/tags/categories.
             task.dependsOn('buildGuides')
-            // Also include the vendored guide corpus so build/dist/guides/<name>/<v>/
-            // ships alongside the main site under https://grails.apache.org/guides/.
+            // Per-version vendored guide corpus.
             task.dependsOn('buildAllGuides')
             task.gitHubSlug.convention(
                     project.providers.environmentVariable('GITHUB_SLUG')
@@ -224,11 +217,11 @@ abstract class PublishMainSiteTask extends DefaultTask {
         runGit(deployRoot, 'config', 'user.name', author)
         runGit(deployRoot, 'config', 'user.email', "${author}@users.noreply.github.com".toString())
 
-        // 4. Mirror the dist tree into the deploy clone (preserve .git/).
+        // 4. Layer the dist tree onto the deploy clone (additive overwrite).
+        // Files only present on the deploy branch (e.g. ASF .asf.yaml) are
+        // preserved; explicit removals must go through a separate cleanup.
         Path deployPath = deployRoot.toPath()
-        Path gitDir = deployPath.resolve('.git')
         Path distPath = distRoot.toPath()
-        deletePathExcept(deployPath, gitDir)
         copyTree(distPath, deployPath)
 
         // 5. Stage changes and detect any actual diff.
@@ -270,41 +263,9 @@ abstract class PublishMainSiteTask extends DefaultTask {
     }
 
     /**
-     * Recursively delete every file and directory under {@code root}
-     * except for {@code preserve} (and its descendants).
-     */
-    private static void deletePathExcept(Path root, Path preserve) {
-        Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
-            @Override
-            FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
-                if (dir == preserve) {
-                    return FileVisitResult.SKIP_SUBTREE
-                }
-                return FileVisitResult.CONTINUE
-            }
-
-            @Override
-            FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                Files.delete(file)
-                return FileVisitResult.CONTINUE
-            }
-
-            @Override
-            FileVisitResult postVisitDirectory(Path dir, IOException exc) {
-                if (dir == root || dir == preserve) {
-                    return FileVisitResult.CONTINUE
-                }
-                if (Files.list(dir).withCloseable { it.findFirst().isEmpty() }) {
-                    Files.delete(dir)
-                }
-                return FileVisitResult.CONTINUE
-            }
-        })
-    }
-
-    /**
      * Copy every file and subdirectory under {@code source} into
-     * {@code target}, replacing existing files.
+     * {@code target}, overwriting existing files. Files only present
+     * on {@code target} are left in place.
      */
     private static void copyTree(Path source, Path target) {
         Files.walkFileTree(source, new SimpleFileVisitor<Path>() {

--- a/buildSrc/src/main/groovy/website/gradle/tasks/PublishMainSiteTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/PublishMainSiteTask.groovy
@@ -33,6 +33,7 @@ import org.gradle.process.ExecOperations
 
 import javax.inject.Inject
 import java.nio.file.FileVisitResult
+import java.nio.file.LinkOption
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.SimpleFileVisitor
@@ -265,13 +266,17 @@ abstract class PublishMainSiteTask extends DefaultTask {
     /**
      * Copy every file and subdirectory under {@code source} into
      * {@code target}, overwriting existing files. Files only present
-     * on {@code target} are left in place.
+     * on {@code target} are left in place. Type conflicts (file where a
+     * directory is needed, or vice versa) replace the conflicting path.
      */
     private static void copyTree(Path source, Path target) {
         Files.walkFileTree(source, new SimpleFileVisitor<Path>() {
             @Override
             FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
                 Path dest = target.resolve(source.relativize(dir).toString())
+                if (Files.exists(dest, LinkOption.NOFOLLOW_LINKS) && !Files.isDirectory(dest, LinkOption.NOFOLLOW_LINKS)) {
+                    Files.delete(dest)
+                }
                 Files.createDirectories(dest)
                 return FileVisitResult.CONTINUE
             }
@@ -279,7 +284,26 @@ abstract class PublishMainSiteTask extends DefaultTask {
             @Override
             FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
                 Path dest = target.resolve(source.relativize(file).toString())
+                if (Files.isDirectory(dest, LinkOption.NOFOLLOW_LINKS)) {
+                    deleteRecursively(dest)
+                }
                 Files.copy(file, dest, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES)
+                return FileVisitResult.CONTINUE
+            }
+        })
+    }
+
+    private static void deleteRecursively(Path root) {
+        Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+            @Override
+            FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                Files.delete(file)
+                return FileVisitResult.CONTINUE
+            }
+
+            @Override
+            FileVisitResult postVisitDirectory(Path dir, IOException exc) {
+                Files.delete(dir)
                 return FileVisitResult.CONTINUE
             }
         })


### PR DESCRIPTION
## Summary

Make `publishMainSite` mirror the build output ADDITIVELY instead of deleting the deploy tree first. Files only present on the deploy branch (ASF `.asf.yaml`, content from prior render pipelines, deploy-side metadata) are preserved.

This restores the original `cp -rv` semantic from the legacy `publish.sh` script. The interim `rsync --delete` semantic introduced wiping deploy-branch-only files on every publish, which deleted ~43k files including the `.asf.yaml` that ASF Infra needs for pubsub mirror routing.

## Operational note

I have already force-pushed `apache/grails-website asf-site-production` back to the last good commit (`8fc559dc8c`, before the first delete-semantic deploy at `2026-04-30T22:18:58Z`). The deploy tree is back to 51,233 files. The `.asf.yaml` is in place. ASF Infra mirror should resume once it sees the restored branch tip.

After this PR merges, future `publishMainSite` runs will only ADD or UPDATE files; they will never delete deploy-branch state.

## Comment cleanup

Trimmed verbose narrative comments across `PublishMainSiteTask`, `RenderGuidesPlugin`, `GuidesTask`, `AsciidoctorWarningGateTask`, and `publish.yml`. The remaining comments describe intent in one or two lines.

Refs #354.