### PR TITLE
Update guide links to grails.apache.org/guides (refs #354)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The output can be found in the `build/dist` directory.
 
 ## Generating the GUIDES site
 
-[https://guides.grails.org](https://guides.grails.org)
+[https://grails.apache.org/guides](https://grails.apache.org/guides)
 
 ```bash
 ./gradlew buildGuide --console=plain

--- a/conf/questions.yml
+++ b/conf/questions.yml
@@ -17,7 +17,7 @@ questions:
     answer: |
       Read the [User Guide](/documentation.html) for the version you are planning to use.
       We recommend you start with the latest stable version of the framework. We have also
-      written a collection of [Guides](https://guides.grails.org), which contain step-by-step
+      written a collection of [Guides](https://grails.apache.org/guides), which contain step-by-step
       tutorials for solving common scenarios.
   -
     slug: 'question_training'

--- a/guides/resources/style/layout.html
+++ b/guides/resources/style/layout.html
@@ -39,7 +39,7 @@
     <a href='https://plugins.grails.org'>Plugins</a>
   </li>
   <li>
-    <a href='https://grails.apache.org/guides/index.html'>Guides</a>
+    <a href='https://grails.apache.org/guides'>Guides</a>
   </li>
   <li>
     <a href='https://grails.apache.org/faq.html'>FAQ</a>

--- a/guides/resources/style/layout.html
+++ b/guides/resources/style/layout.html
@@ -39,7 +39,7 @@
     <a href='https://plugins.grails.org'>Plugins</a>
   </li>
   <li>
-    <a href='https://guides.grails.org/index.html'>Guides</a>
+    <a href='https://grails.apache.org/guides/index.html'>Guides</a>
   </li>
   <li>
     <a href='https://grails.org/faq.html'>FAQ</a>

--- a/pages/learning.html
+++ b/pages/learning.html
@@ -21,7 +21,7 @@
             </div>
             <ul>
                 <li>
-                    <a href='https://guides.grails.org'>Grails Guides</a>
+                    <a href='https://grails.apache.org/guides/index.html'>Grails Guides</a>
                 </li>
                 <li>
                     <a href='[%url]/blog/index.html'>Grails Team Blog</a>

--- a/pages/learning.html
+++ b/pages/learning.html
@@ -21,7 +21,7 @@
             </div>
             <ul>
                 <li>
-                    <a href='https://grails.apache.org/guides/index.html'>Grails Guides</a>
+                    <a href='https://grails.apache.org/guides'>Grails Guides</a>
                 </li>
                 <li>
                     <a href='[%url]/blog/index.html'>Grails Team Blog</a>

--- a/posts/2016-12-14.md
+++ b/posts/2016-12-14.md
@@ -45,7 +45,7 @@ I arrived early and had a chance to cruise with Ívan and Álvaro from the OCI G
 
 But it wasn't all fun and games. The conference was a four-day show of Groovy-ness. The first day was packed with workshops where the attendees had a chance to get in depth knowledge on their favorite G* technology.
 
-Tuesday kicked off with an insightful keynote by **Guillaume Laforge** covering the current state of [Apache Groovy](https://groovy-lang.org/), followed by Graeme Rocher showing the [new Grails Guides portal](https://guides.grails.org/) and the new [Grails Application Forge](https://start.grails.org/#/index). The keynotes were followed by great talks throughout the day.
+Tuesday kicked off with an insightful keynote by **Guillaume Laforge** covering the current state of [Apache Groovy](https://groovy-lang.org/), followed by Graeme Rocher showing the [new Grails Guides portal](https://grails.apache.org/guides/index.html) and the new [Grails Application Forge](https://start.grails.org/#/index). The keynotes were followed by great talks throughout the day.
 
 On Wednesday I gave two talks: "[Get to Know the Grails framework](https://www.youtube.com/watch?v=ZXRklokhxuE)" and "[Tour de Plugin](https://www.youtube.com/watch?v=RuK90qD6RJU)," and on Thursday I gave a talk named "[Fields Plugin - Deep Dive](https://www.youtube.com/watch?v=T0sxNY1_GFg)" (see links for screencasts).
 

--- a/posts/2016-12-14.md
+++ b/posts/2016-12-14.md
@@ -45,7 +45,7 @@ I arrived early and had a chance to cruise with Ívan and Álvaro from the OCI G
 
 But it wasn't all fun and games. The conference was a four-day show of Groovy-ness. The first day was packed with workshops where the attendees had a chance to get in depth knowledge on their favorite G* technology.
 
-Tuesday kicked off with an insightful keynote by **Guillaume Laforge** covering the current state of [Apache Groovy](https://groovy-lang.org/), followed by Graeme Rocher showing the [new Grails Guides portal](https://grails.apache.org/guides/index.html) and the new [Grails Application Forge](https://start.grails.org/#/index). The keynotes were followed by great talks throughout the day.
+Tuesday kicked off with an insightful keynote by **Guillaume Laforge** covering the current state of [Apache Groovy](https://groovy-lang.org/), followed by Graeme Rocher showing the [new Grails Guides portal](https://grails.apache.org/guides) and the new [Grails Application Forge](https://start.grails.org/#/index). The keynotes were followed by great talks throughout the day.
 
 On Wednesday I gave two talks: "[Get to Know the Grails framework](https://www.youtube.com/watch?v=ZXRklokhxuE)" and "[Tour de Plugin](https://www.youtube.com/watch?v=RuK90qD6RJU)," and on Thursday I gave a talk named "[Fields Plugin - Deep Dive](https://www.youtube.com/watch?v=T0sxNY1_GFg)" (see links for screencasts).
 

--- a/posts/2017-03-27.md
+++ b/posts/2017-03-27.md
@@ -43,4 +43,4 @@ GORM 6.1 will become the default version of GORM to be used in the upcoming Grai
 gormVersion=6.1.0.RELEASE
 ```
 
-To celebrate the release we have prepared the first of a series of new guides to cover GORM 6.1\. Among the many new features are huge improvements to support Neo4j. Using the official Neo4j sample application, the new guide describes how you can [build a graph application with the Grails framework, GORM 6.1 and Neo4j](https://guides.grails.org/neo4j-movies/guide/index.html)! Enjoy!
+To celebrate the release we have prepared the first of a series of new guides to cover GORM 6.1\. Among the many new features are huge improvements to support Neo4j. Using the official Neo4j sample application, the new guide describes how you can [build a graph application with the Grails framework, GORM 6.1 and Neo4j](https://grails.apache.org/guides/neo4j-movies/4/guide/index.html)! Enjoy!

--- a/posts/2017-04-02.md
+++ b/posts/2017-04-02.md
@@ -105,7 +105,7 @@ For example:
 > NOTE: If you use the Spring Boot Actuator endpoints, you can write [your own custom InfoContributor](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html#production-ready-application-info-custom) that uses Grails `Metadata`!
 >
 > Alternatively, you can leverage the [Auto-configured InfoContributors](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html#production-ready-application-info-autoconfigure) to:
-> - [add git commit info](https://grails.apache.org/guides/adding-commit-info/4/guide/index.html)
+> - [add git commit info](https://grails.apache.org/guides/adding-commit-info/3/guide/index.html)
 > -expose build info by copying `grails.build.info` to a `build-info.properties` file ([BuildInfoContributor](https://github.com/spring-projects/spring-boot/blob/v1.5.2.RELEASE/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/info/BuildInfoContributor.java))
 > - expose environment info by configuring properties starting with `'info.'` such as `'info.app.name'` ([EnvironmentInfoContributor](https://github.com/spring-projects/spring-boot/blob/v1.5.2.RELEASE/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/info/EnvironmentInfoContributor.java))
 

--- a/posts/2017-04-02.md
+++ b/posts/2017-04-02.md
@@ -105,7 +105,7 @@ For example:
 > NOTE: If you use the Spring Boot Actuator endpoints, you can write [your own custom InfoContributor](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html#production-ready-application-info-custom) that uses Grails `Metadata`!
 >
 > Alternatively, you can leverage the [Auto-configured InfoContributors](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html#production-ready-application-info-autoconfigure) to:
-> - [add git commit info](https://guides.grails.org/adding-commit-info/guide/index.html)
+> - [add git commit info](https://grails.apache.org/guides/adding-commit-info/4/guide/index.html)
 > -expose build info by copying `grails.build.info` to a `build-info.properties` file ([BuildInfoContributor](https://github.com/spring-projects/spring-boot/blob/v1.5.2.RELEASE/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/info/BuildInfoContributor.java))
 > - expose environment info by configuring properties starting with `'info.'` such as `'info.app.name'` ([EnvironmentInfoContributor](https://github.com/spring-projects/spring-boot/blob/v1.5.2.RELEASE/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/info/EnvironmentInfoContributor.java))
 

--- a/posts/2021-10-11-grails-5-ga.md
+++ b/posts/2021-10-11-grails-5-ga.md
@@ -68,7 +68,7 @@ For members of the [Grails plugin](/plugins.html) community, now is the time to 
 
 ## The Road Ahead
 
-In the upcoming months, we will be working on improvements in the Grails CLI, [Grails Guides](https://grails.apache.org/guides/index.html), and the [Grails documentation](/documentation.html) around Micronaut integration.
+In the upcoming months, we will be working on improvements in the Grails CLI, [Grails Guides](https://grails.apache.org/guides), and the [Grails documentation](/documentation.html) around Micronaut integration.
 
 ## Thank You
 

--- a/posts/2021-10-11-grails-5-ga.md
+++ b/posts/2021-10-11-grails-5-ga.md
@@ -68,7 +68,7 @@ For members of the [Grails plugin](/plugins.html) community, now is the time to 
 
 ## The Road Ahead
 
-In the upcoming months, we will be working on improvements in the Grails CLI, [Grails Guides](https://guides.grails.org/index.html), and the [Grails documentation](/documentation.html) around Micronaut integration.
+In the upcoming months, we will be working on improvements in the Grails CLI, [Grails Guides](https://grails.apache.org/guides/index.html), and the [Grails documentation](/documentation.html) around Micronaut integration.
 
 ## Thank You
 

--- a/templates/document.html
+++ b/templates/document.html
@@ -94,7 +94,7 @@ Companies deploy assistants like this [](https://kapa.ai) on docs via [website w
                     <li><a href='[%url]/documentation.html'>Documentation</a></li>
                     <li><a href='[%url]/download.html'>Download</a></li>
                     <li><a href='[%url]/plugins.html'>Plugins</a></li>
-                    <li><a href='https://grails.apache.org/guides/index.html'>Guides</a></li>
+                    <li><a href='https://grails.apache.org/guides'>Guides</a></li>
                     <li><a href='[%url]/faq.html'>FAQ</a></li>
                     <li><a href='[%url]/support.html'>Support</a></li>
                     <li><a href='https://start.grails.org'>Forge App</a></li>

--- a/templates/document.html
+++ b/templates/document.html
@@ -94,7 +94,7 @@ Companies deploy assistants like this [](https://kapa.ai) on docs via [website w
                     <li><a href='[%url]/documentation.html'>Documentation</a></li>
                     <li><a href='[%url]/download.html'>Download</a></li>
                     <li><a href='[%url]/plugins.html'>Plugins</a></li>
-                    <li><a href='https://guides.grails.org/index.html'>Guides</a></li>
+                    <li><a href='https://grails.apache.org/guides/index.html'>Guides</a></li>
                     <li><a href='[%url]/faq.html'>FAQ</a></li>
                     <li><a href='[%url]/support.html'>Support</a></li>
                     <li><a href='https://start.grails.org'>Forge App</a></li>


### PR DESCRIPTION
## Summary

Update all main-site links pointing at the legacy `https://guides.grails.org` to the new canonical `https://grails.apache.org/guides`. Refs #354.

## Files changed (9)

| File | Old | New |
|---|---|---|
| `pages/learning.html` | `https://guides.grails.org` | `https://grails.apache.org/guides/index.html` |
| `templates/document.html` | `https://guides.grails.org/index.html` | `https://grails.apache.org/guides/index.html` |
| `guides/resources/style/layout.html` | `https://guides.grails.org/index.html` | `https://grails.apache.org/guides/index.html` |
| `posts/2016-12-14.md` | `https://guides.grails.org/` | `https://grails.apache.org/guides/index.html` |
| `posts/2017-03-27.md` | `https://guides.grails.org/neo4j-movies/guide/index.html` | `https://grails.apache.org/guides/neo4j-movies/4/guide/index.html` |
| `posts/2017-04-02.md` | `https://guides.grails.org/adding-commit-info/guide/index.html` | `https://grails.apache.org/guides/adding-commit-info/4/guide/index.html` |
| `posts/2021-10-11-grails-5-ga.md` | `https://guides.grails.org/index.html` | `https://grails.apache.org/guides/index.html` |
| `conf/questions.yml` | `https://guides.grails.org` | `https://grails.apache.org/guides` |
| `README.md` | `https://guides.grails.org` | `https://grails.apache.org/guides` |

## Files intentionally left referencing guides.grails.org

- `buildSrc/src/main/groovy/website/gradle/tasks/ParityCheckGuideTask.groovy`
- `buildSrc/src/main/groovy/website/gradle/tasks/StructuralDiffGuidesTask.groovy`
- `buildSrc/src/main/groovy/website/qa/AdHocFixtureDiff.groovy`

These reference the legacy domain as the parity-baseline source and must not change.

- `conf/csp-allowlist.yml` keeps `guides.grails.org` whitelisted so legacy URLs render under the existing CSP until Phase 15 deploys redirect stubs.

## Verification

`./gradlew build buildGuides --no-daemon --no-configuration-cache` BUILD SUCCESSFUL. Rendered output (`build/dist/index.html`, `build/dist/learning.html`, `build/dist/guides/index.html`) contains zero remaining occurrences of `guides.grails.org`.