### PR TITLE
Render guides with the legacy single-page theme (refs #354)

### DIFF
--- a/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
@@ -64,8 +64,12 @@ import website.gradle.tasks.VendorGuideTask
  *
  * <p>The renderer itself is the vendored {@code grails.doc.*} subtree (see
  * {@code buildSrc/VENDOR.md}). Templates and theme assets live in
- * {@code buildSrc/src/main/template/} and are passed to
- * {@link PublishGuideTask#getResourcesDir()} as a filesystem path.</p>
+ * {@code guides/resources/} and are passed to
+ * {@link PublishGuideTask#getResourcesDir()} as a filesystem path. The
+ * {@code guides/resources/style/layout.html} template renders the legacy
+ * single-page guide chrome; {@code guideItem.html}, {@code section.html},
+ * {@code index.html}, {@code menu.html}, and {@code referenceItem.html}
+ * round out the bundle DocPublisher expects.</p>
  */
 @CompileStatic
 class RenderGuidesPlugin {

--- a/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
@@ -76,7 +76,7 @@ class RenderGuidesPlugin {
     static final String PARITY_AGGREGATE_TASK = 'parityCheckAllGuides'
     static final String VENDOR_AGGREGATE_TASK = 'vendorAllGuides'
     static final String GUIDES_YML_PATH = 'conf/guides.yml'
-    static final String VENDOR_TEMPLATE_PATH = 'buildSrc/src/main/template'
+    static final String GUIDE_TEMPLATE_PATH = 'guides/resources'
     static final String PARITY_BASELINE_ROOT = 'buildSrc/src/test/resources/parity-baseline'
     /**
      * Default upstream-checkout root, relative to the project root's
@@ -95,7 +95,7 @@ class RenderGuidesPlugin {
         }
 
         Directory templateRoot = project.rootProject.layout.projectDirectory
-                .dir(VENDOR_TEMPLATE_PATH)
+                .dir(GUIDE_TEMPLATE_PATH)
 
         Wiring wiring = registerPerVersionTasks(
                 project, templateRoot, guidesYml)
@@ -236,6 +236,8 @@ class RenderGuidesPlugin {
                                     "dist/guides/${guideName}/${versionKey}"))
                     task.asciidoc.set(true)
                     task.properties.set(attributes)
+                    // Drives the "Improve this doc" buttons in section.html.
+                    task.sourceRepo.set("https://github.com/apache/grails-static-website/edit/master/${sourcePath}".toString())
                     task.notCompatibleWithConfigurationCache(
                             'Vendored grails.doc.gradle.PublishGuideTask references Project + AntBuilder')
                     // Order after the main-site tasks since they share build/ as @OutputDirectory.
@@ -245,6 +247,16 @@ class RenderGuidesPlugin {
                             SitemapTask.NAME, AssetsTask.NAME,
                             DocumentationTask.NAME, DownloadTask.NAME,
                             QuestionsTask.NAME, GuidesTask.NAME)
+                    // The DocPublisher emits the legacy single-page chrome to
+                    // single.html and a TOC-only stub to index.html. Promote the
+                    // single page to the canonical /guide/index.html URL.
+                    task.doLast {
+                        File singleHtml = new File(task.targetDir.get().asFile, 'guide/single.html')
+                        if (singleHtml.isFile()) {
+                            File indexHtml = new File(task.targetDir.get().asFile, 'guide/index.html')
+                            indexHtml.bytes = singleHtml.bytes
+                        }
+                    }
                 }
                 wiring.renderTaskNames << renderTaskName
 
@@ -353,7 +365,11 @@ class RenderGuidesPlugin {
         // Always surface the version key so :version{} attribute resolutions work.
         attrs.putIfAbsent('version', versionKey)
         attrs.putIfAbsent('grails.version', versionKey)
-
+        // Legacy guide layout templates expect these names directly.
+        attrs.putIfAbsent('grailsVersion', versionKey)
+        if (guide.authors instanceof List) {
+            attrs.putIfAbsent('authors', (guide.authors as List).join(', '))
+        }
         attrs
     }
 }

--- a/guides/resources/style/index.html
+++ b/guides/resources/style/index.html
@@ -1,0 +1,34 @@
+<html>
+    <head>
+        <title>${title} ${version} Reference Documentation</title>
+        <link rel="icon" href="img/favicon.ico" type="image/x-icon"/>
+        <link rel="shortcut icon" href="img/favicon.ico" type="image/x-icon"/>
+        <!-- Matomo -->
+        <script>
+            var _paq = window._paq = window._paq || [];
+            /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+            _paq.push(["setDoNotTrack", true]);
+            _paq.push(["disableCookies"]);
+            _paq.push(['trackPageView']);
+            _paq.push(['enableLinkTracking']);
+            (function() {
+                var u="https://analytics.apache.org/";
+                _paq.push(['setTrackerUrl', u+'matomo.php']);
+                _paq.push(['setSiteId', '79']);
+                var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+            })();
+        </script>
+        <!-- End Matomo Code -->
+    </head>
+    <frameset cols="20%,80%">
+        <frame src="ref/menu.html" name="leftFrame" title="index for guide"/>
+        <frame src="guide/index.html" name="mainFrame" title="main guide contents" scrolling="yes"/>
+
+        <noframes>
+            <h2>Frame Alert</h2>
+            <p/>
+            This document is designed to be viewed using the frames feature. If you see this message, you are using a non-frame-capable web client.
+        </noframes>
+    </frameset>
+</html>

--- a/guides/resources/style/layout.html
+++ b/guides/resources/style/layout.html
@@ -151,35 +151,21 @@
 </ul></nav>
   </div>
 </footer><div>
-  <script type='text/javascript'>
-              (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-              ga('create', 'UA-82213539-2', 'auto');
-              ga('send', 'pageview');
-</script>
-  <script type='text/javascript'>
-adroll_adv_id = "HBWJH4CQCJGS5DJRSB4Z4D";
-adroll_pix_id = "IVEQYFOZXZAPZMDVQH7BFE";
-/* OPTIONAL: provide email to improve user identification */
-/* adroll_email = "username@example.com"; */
-(function () {
-    var _onload = function(){
-        if (document.readyState && !/loaded|complete/.test(document.readyState)){setTimeout(_onload, 10);return}
-        if (!window.__adroll_loaded){__adroll_loaded=true;setTimeout(_onload, 50);return}
-        var scr = document.createElement("script");
-        var host = (("https:" == document.location.protocol) ? "https://s.adroll.com" : "http://a.adroll.com");
-        scr.setAttribute('async', 'true');
-        scr.type = "text/javascript";
-        scr.src = host + "/j/roundtrip.js";
-        ((document.getElementsByTagName('head') || [null])[0] ||
-            document.getElementsByTagName('script')[0].parentNode).appendChild(scr);
-    };
-    if (window.addEventListener) {window.addEventListener('load', _onload, false);}
-    else {window.attachEvent('onload', _onload)}
-}());            
-</script>
+  <!-- Matomo -->
+  <script>
+    var _paq = window._paq = window._paq || [];
+    _paq.push(['setDoNotTrack', true]);
+    _paq.push(['disableCookies']);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u = 'https://analytics.apache.org/';
+      _paq.push(['setTrackerUrl', u + 'matomo.php']);
+      _paq.push(['setSiteId', '79']);
+      var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+      g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
+    })();
+  </script>
+  <!-- End Matomo Code -->
 </div></body>
 </html>

--- a/guides/resources/style/layout.html
+++ b/guides/resources/style/layout.html
@@ -14,38 +14,38 @@
   </head>
   <body class='guide'><header class='mainheader'>
   <div class='content'>
-    <a href='https://grails.org/index.html'><img class='grailslogo' src='/images/grails_logo.svg' alt='Grails Logo' /></a>
+    <a href='https://grails.apache.org/index.html'><img class='grailslogo' src='/images/grails_logo.svg' alt='Grails Logo' /></a>
     <a href='javascript:show(&apos;topmenus&apos;, &apos;showNavigationLink&apos;)' id='showNavigationLink' class='mobile align-center'>Show Navigation</a>
     <div id='topmenus'>
       <nav class='secondarymenu' id='secondarymenu'><ul>
   <li>
-    <a href='https://grails.org/learning.html'>Learning</a>
+    <a href='https://grails.apache.org/learning.html'>Learning</a>
   </li>
   <li>
-    <a href='https://grails.org/community.html'>Community</a>
+    <a href='https://grails.apache.org/community.html'>Community</a>
   </li>
   <li>
-    <a href='https://grails.org/search.html'>Search</a>
+    <a href='https://grails.apache.org/search.html'>Search</a>
   </li>
 </ul></nav>
       <nav class='mainmenu' id='mainmenu'><ul>
   <li>
-    <a href='https://grails.org/documentation.html'>Documentation</a>
+    <a href='https://grails.apache.org/documentation.html'>Documentation</a>
   </li>
   <li>
-    <a href='https://grails.org/download.html'>Download</a>
+    <a href='https://grails.apache.org/download.html'>Download</a>
   </li>
   <li>
     <a href='https://plugins.grails.org'>Plugins</a>
   </li>
   <li>
-    <a href='https://guides.grails.org/index.html'>Guides</a>
+    <a href='https://grails.apache.org/guides/index.html'>Guides</a>
   </li>
   <li>
-    <a href='https://grails.org/faq.html'>FAQ</a>
+    <a href='https://grails.apache.org/faq.html'>FAQ</a>
   </li>
   <li>
-    <a href='https://grails.org/support.html'>Support</a>
+    <a href='https://grails.apache.org/support.html'>Support</a>
   </li>
 </ul></nav>
     </div>
@@ -146,7 +146,7 @@
     <a href='http://www.apache.org/licenses/LICENSE-2.0.html'>Apache 2 License</a>
   </li>
   <li>
-    <a href='https://grails.org/buildstatus.html'>Build Status</a>
+    <a href='https://grails.apache.org/buildstatus.html'>Build Status</a>
   </li>
 </ul></nav>
   </div>

--- a/guides/resources/style/menu.html
+++ b/guides/resources/style/menu.html
@@ -1,0 +1,51 @@
+<html>
+    <head>
+        <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+        <title>menu</title>
+        <link rel="stylesheet" href="../css/menu.css" type="text/css" media="screen" title="Menu" charset="utf-8"/>
+        <!-- Matomo -->
+        <script>
+            var _paq = window._paq = window._paq || [];
+            /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+            _paq.push(["setDoNotTrack", true]);
+            _paq.push(["disableCookies"]);
+            _paq.push(['trackPageView']);
+            _paq.push(['enableLinkTracking']);
+            (function() {
+                var u="https://analytics.apache.org/";
+                _paq.push(['setTrackerUrl', u+'matomo.php']);
+                _paq.push(['setSiteId', '79']);
+                var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+            })();
+        </script>
+        <!-- End Matomo Code -->
+        <script
+            async
+            src="https://widget.kapa.ai/kapa-widget.bundle.js"
+            data-website-id="d804a9f2-51a2-414c-97f7-12f2a1ba4609"
+            data-project-name="Apache Grails"
+            data-project-color="#3F4346"
+            data-font-family="system-ui,-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,Segoe UI,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;"
+            data-project-logo="https://grails.apache.org/images/grails.png"
+            data-modal-override-open-id="ask-ai-input"
+            data-modal-override-open-class="search-input"
+            data-user-analytics-fingerprint-enabled="true"
+            data-modal-title="Apache Grails AI Assistant"
+            data-modal-example-questions-title="Try asking me..."
+            data-modal-disclaimer="This is a custom LLM for Apache Grails using [documentation](https://docs.grails.org/latest/), [groovy documentation](https://docs.groovy-lang.org/docs/groovy-4.0.28/html/documentation/) [github issues](https://github.com/apache/grails-core/issues) and more.\n\nCompanies deploy assistants like this [](https://kapa.ai) on docs via [website widget](https://docs.kapa.ai/integrations/website-widget) (Docker, Reddit), in [support forms](https://docs.kapa.ai/integrations/support-form-deflector) for ticket deflection (Monday.com, Mapbox), or as [an internal assistant](https://docs.kapa.ai/integrations/internal-assistant) with access to private sources."
+            data-modal-example-questions="How does database migration work?,How does Spring Security work?"
+            data-button-text-color="#FBB576"
+            data-modal-header-bg-color="#FFFFFF"
+            data-modal-title-color="#FBB576"
+            data-consent-required="true"
+            data-consent-screen-disclaimer="By clicking &quot;I agree, let&#39;s chat&quot;, you consent to the use of the AI assistant in accordance with kapa.ai&#39;s [Privacy Policy](https://www.kapa.ai/content/privacy-policy). This service uses reCAPTCHA, which requires your consent to Google&#39;s [Privacy Policy](https://policies.google.com/privacy) and [Terms of Service](https://policies.google.com/terms). By proceeding, you explicitly agree to both kapa.ai&#39;s and Google&#39;s privacy policies.">
+        ></script>
+    </head>
+    <body>
+        <div style="text-align:center;" class="menuTitle">
+            <a href="../guide/index.html" target="mainFrame">User Guide</a>
+        </div>
+        ${menu}
+    </body>
+</html>

--- a/guides/resources/style/referenceItem.html
+++ b/guides/resources/style/referenceItem.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+                      "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head>
+    <title>${title.encodeAsHtml()} ${version}</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <link rel="stylesheet" href="${resourcesPath}/css/main.css" type="text/css" media="screen, print" title="Style" charset="utf-8"/>
+    <link rel="stylesheet" href="${resourcesPath}/css/pdf.css" type="text/css" media="print" title="PDF" charset="utf-8"/>
+    <script type="text/javascript">
+        function addJsClass(el) {
+            var classes = document.body.className.split(" ");
+            classes.push("js");
+            document.body.className = classes.join(" ");
+        }
+    </script>
+    <style>
+        .contribute-btn {
+            bottom: 0px;
+        }
+    </style>
+    <!-- Matomo -->
+    <script>
+        var _paq = window._paq = window._paq || [];
+        /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+        _paq.push(["setDoNotTrack", true]);
+        _paq.push(["disableCookies"]);
+        _paq.push(['trackPageView']);
+        _paq.push(['enableLinkTracking']);
+        (function() {
+            var u="https://analytics.apache.org/";
+            _paq.push(['setTrackerUrl', u+'matomo.php']);
+            _paq.push(['setSiteId', '79']);
+            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+            g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+        })();
+    </script>
+    <!-- End Matomo Code -->
+    <script
+        async
+        src="https://widget.kapa.ai/kapa-widget.bundle.js"
+        data-website-id="d804a9f2-51a2-414c-97f7-12f2a1ba4609"
+        data-project-name="Apache Grails"
+        data-project-color="#3F4346"
+        data-font-family="system-ui,-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,Segoe UI,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;"
+        data-project-logo="https://grails.apache.org/images/grails.png"
+        data-modal-override-open-id="ask-ai-input"
+        data-modal-override-open-class="search-input"
+        data-user-analytics-fingerprint-enabled="true"
+        data-modal-title="Apache Grails AI Assistant"
+        data-modal-example-questions-title="Try asking me..."
+        data-modal-disclaimer="This is a custom LLM for Apache Grails using [documentation](https://docs.grails.org/latest/), [groovy documentation](https://docs.groovy-lang.org/docs/groovy-4.0.28/html/documentation/) [github issues](https://github.com/apache/grails-core/issues) and more.\n\nCompanies deploy assistants like this [](https://kapa.ai) on docs via [website widget](https://docs.kapa.ai/integrations/website-widget) (Docker, Reddit), in [support forms](https://docs.kapa.ai/integrations/support-form-deflector) for ticket deflection (Monday.com, Mapbox), or as [an internal assistant](https://docs.kapa.ai/integrations/internal-assistant) with access to private sources."
+        data-modal-example-questions="How does database migration work?,How does Spring Security work?"
+        data-button-text-color="#FBB576"
+        data-modal-header-bg-color="#FFFFFF"
+        data-modal-title-color="#FBB576"
+        data-consent-required="true"
+        data-consent-screen-disclaimer="By clicking &quot;I agree, let&#39;s chat&quot;, you consent to the use of the AI assistant in accordance with kapa.ai&#39;s [Privacy Policy](https://www.kapa.ai/content/privacy-policy). This service uses reCAPTCHA, which requires your consent to Google&#39;s [Privacy Policy](https://policies.google.com/privacy) and [Terms of Service](https://policies.google.com/terms). By proceeding, you explicitly agree to both kapa.ai&#39;s and Google&#39;s privacy policies.">
+    ></script>
+</head>
+
+<body class="body" onload="addJsClass();">
+
+<div id="navigation">
+    <div class="navTitle">
+        <% if (logo) { %>
+        <span id="logo">${logo}</span>
+        <% } %>
+        ${docTitle.encodeAsHtml()}
+    </div>
+
+    <div class="navLinks">
+        <ul>
+            <li>
+                <div id="nav-summary" onmouseover="toggleNavSummary(false)" onmouseout="toggleNavSummary(true)">
+                    <a href="${path}/guide/index.html" class="button">Table of contents</a>
+
+                    <div id="nav-summary-childs">
+                        <% toc.children.eachWithIndex { ch, i -> %>
+                        <div class="toc-item" style="margin-left:0"><a href="${path}/guide/${ch.name.encodeAsUrlPath().encodeAsHtml()}.html"><strong>${i + 1}</strong><span>${ch.title.encodeAsHtml()}</span></a>
+                        </div>
+                        <% } %>
+                    </div>
+                </div>
+            </li>
+            <li class="separator selected">
+                <a id="ref-button" onclick="localToggle(); return false;" href="#">Quick Reference</a>
+            </li>
+        </ul>
+    </div>
+</div>
+
+
+<table id="colset" border="0" cellpadding="0" cellspacing="0">
+    <tr>
+        <td id="col1">
+            <div id="main" class="reference corner-all">
+
+                <span id='toggle-col1' class="toggle">(<a href="#" onclick="localToggle(); return false;">Quick Reference</a>)</span>
+                <% if(sourceRepo) { %>
+                <div class='contribute-btn'>
+                    <button type='button' class='btn btn-default' onclick='window.location.href="${sourceRepo}/${sourcePath}"'>
+                        <i class='fa fa-pencil-square-o'></i> Improve this doc
+                    </button>
+                </div>
+                <% } %>
+
+                ${content}
+            </div>
+        </td>
+        <td id="col2">
+            <div class="local clearfix">
+                <div class="local-title">
+                    <a href="${path}/guide/index.html" target="mainFrame">Quick Reference</a>
+                    <span class="toggle">(<a href="#" onclick="localToggle(); return false;">hide</a>)</span>
+                </div>
+                <div class="menu">
+                    <% for (cat in refMenu) { %>
+                    <div class="menu-block">
+                        <h1 class="menu-title" onclick="toggleRef(nextElement(this))">${cat.name.encodeAsHtml()}</h1>
+                        <div class="menu-sub${ cat.name == section ? ' selected' : ''}">
+                            <% if (cat.usage.exists()) { %>
+                            <div class="menu-item"><a href="${path}/ref/${cat.name.encodeAsUrlPath().encodeAsHtml()}/Usage.html">Usage</a></div>
+                            <% } %>
+                            <% for (txt in cat.sections) { %>
+                            <div class="menu-item"><a href="${path}/ref/${cat.name.encodeAsUrlPath().encodeAsHtml()}/${txt.name[0..-6].encodeAsUrlPath().encodeAsHtml()}.html">${txt.name[0..-6].encodeAsHtml()}</a>
+                            </div>
+                            <% } %>
+                        </div>
+                    </div>
+                    <% } %>
+                </div>
+            </div>
+        </td>
+    </tr>
+</table>
+
+<div id="footer">
+    ${copyright}
+    ${footer}
+</div>
+
+
+<script type="text/javascript" src="${resourcesPath}/js/docs.js"></script>
+
+</body>
+</html>

--- a/guides/resources/style/section.html
+++ b/guides/resources/style/section.html
@@ -1,0 +1,12 @@
+<% def hLevel = level == 0 ? 1 : 2 %>
+<% if (legacyLinks[name]) { %><a name="${legacyLinks[name].encodeAsHtml()}"><!-- Legacy link --></a><% } %>
+<h$hLevel id="${name.encodeAsHtml()}">${sectionNumber} ${title}</h$hLevel>
+<% if(sourceRepo) { %>
+<div class='contribute-btn'>
+    <button type='button' class='btn btn-default' onclick='window.location.href="${sourceRepo}/guide/${sourcePath}"'>
+        <i class='fa fa-pencil-square-o'></i> Improve this doc
+    </button>
+</div>
+<% } %>
+
+${content}

--- a/guides/resources/style/section.html
+++ b/guides/resources/style/section.html
@@ -1,6 +1,6 @@
 <% def hLevel = level == 0 ? 1 : 2 %>
 <% if (legacyLinks[name]) { %><a name="${legacyLinks[name].encodeAsHtml()}"><!-- Legacy link --></a><% } %>
-<h$hLevel id="${name.encodeAsHtml()}">${sectionNumber} ${title}</h$hLevel>
+<h$hLevel id="${name.encodeAsHtml()}">${sectionNumber} ${title.encodeAsHtml()}</h$hLevel>
 <% if(sourceRepo) { %>
 <div class='contribute-btn'>
     <button type='button' class='btn btn-default' onclick='window.location.href="${sourceRepo}/guide/${sourcePath}"'>


### PR DESCRIPTION
## Summary

Switch the guide renderer from the grails-doc reference-manual template bundle to the legacy single-page guide bundle. The cutover deploy mistakenly pointed `PublishGuideTask.resourcesDir` at `buildSrc/src/main/template` (reference-manual chrome), which produced the two-column reference layout for every guide. The legacy single-page chrome lives at `guides/resources/` and was just unused.

After this PR a guide renders with the same look as `https://guides.grails.org/<name>/guide/index.html`: `<body class='guide'>`, `mainheader` + `mainmenu` + `secondarymenu`, GitHub clone aside, inline TOC, inline `Improve this doc` buttons next to each heading, Grails Training widget.

## Changes

1. `RenderGuidesPlugin.groovy`
   - `GUIDE_TEMPLATE_PATH` swaps from `buildSrc/src/main/template` to `guides/resources`.
   - `PublishGuideTask.sourceRepo` now points at `https://github.com/apache/grails-static-website/edit/master/<sourcePath>` so the `Improve this doc` buttons land on the vendored source.
   - `manifestToAttributes` backfills the legacy template aliases `grailsVersion` and `authors`.
   - A `doLast` step copies `guide/single.html` over `guide/index.html` so the canonical `/guide/index.html` URL serves the single-page rendering instead of the TOC stub.

2. `guides/resources/style/` gains four template files (`section.html`, `index.html`, `menu.html`, `referenceItem.html`) ported from the now-unused grails-doc bundle so DocPublisher has a complete template set.

3. `guides/resources/style/layout.html` + `guideItem.html` get their hard-coded `grails.org` and `guides.grails.org` nav links updated to `grails.apache.org`, matching the rest of the cutover.

## Local verification

- `./gradlew clean buildAllGuides --no-daemon --no-configuration-cache` -> BUILD SUCCESSFUL
- `build/dist/guides/grails-database-migration/6/guide/index.html` is now 64 KB (was 11 KB), single-page, contains `mainheader` + `mainmenu` + `Improve this doc` buttons.
- Sampled 3 guides (`grails-database-migration/6`, `creating-your-first-grails-app/6`, `adding-commit-info/3`) all render to substantial single-page output.

## Out of scope (follow-up)

- Chapter pages at `training.html`, `gettingStarted.html`, etc. still use the grails-doc 2-column `guideItem.html` template. Most users will hit the canonical single-page `index.html` so this is a secondary concern, but a follow-up could redirect those URLs to `index.html#<chapter>` anchors.

Refs #354.