### PR TITLE
Centralize site chrome + align guide pages with main site (refs #354)

### DIFF
--- a/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
@@ -200,17 +200,22 @@ class RenderGuidesPlugin {
                 File manifestFile = new File(versionDir, 'manifest.yml')
                 Map<String, Object> attributes = manifestToAttributes(
                         manifestFile, guide, version, versionKey)
+                injectSitePartials(project, attributes)
 
                 String stageTaskName = "stageGuideSource_${safeName}_${safeVersion}"
                 String renderTaskName = "renderGuide_${safeName}_${safeVersion}"
                 String stagedRelPath = "staged-guides/${guideName}/${versionKey}"
 
+                // {commondir} resolves relative to each guide's .adoc file,
+                // pointing at the staged copy of guides/common/.
+                attributes.put('commondir', 'common')
+
                 // Stage the per-version source into a working layout that
-                // DocPublisher expects: <staged>/guide/*.adoc + toc.yml.
-                // Our fixture stores toc.yml at the version root (alongside
-                // manifest.yml) for self-containedness; the renderer wants
-                // it inside guide/. The Sync task does the rearrangement
-                // without mutating the fixture in source control.
+                // DocPublisher expects: <staged>/guide/*.adoc + toc.yml. The
+                // shared guides/common/ snippets are copied alongside as
+                // <staged>/guide/common/ so {commondir} resolves cleanly.
+                File commonDirSrc = project.rootProject.layout.projectDirectory
+                        .dir('guides/common').asFile
                 project.tasks.register(stageTaskName, org.gradle.api.tasks.Sync) { stage ->
                     stage.group = GROUP
                     stage.description = "Stages ${guideName} v${versionKey} source for the vendored grails-doc renderer"
@@ -223,6 +228,11 @@ class RenderGuidesPlugin {
                     if (rootToc.isFile()) {
                         stage.from(rootToc) {
                             into 'guide'
+                        }
+                    }
+                    if (commonDirSrc.isDirectory()) {
+                        stage.from(commonDirSrc) {
+                            into 'guide/common'
                         }
                     }
                 }
@@ -333,6 +343,21 @@ class RenderGuidesPlugin {
      * must be scalar.</p>
      */
     @CompileDynamic
+    /**
+     * Reads the shared chrome partials from {@code templates/partials/} and
+     * exposes them as {@code siteHead}, {@code siteHeader}, {@code siteFooter}
+     * so the legacy guide layout can substitute them via Groovy {@code ${...}}.
+     */
+    private static void injectSitePartials(Project project, Map<String, Object> attrs) {
+        ['siteHead': 'site-head', 'siteHeader': 'site-header', 'siteFooter': 'site-footer'].each { key, partial ->
+            File f = project.rootProject.layout.projectDirectory
+                    .file("templates/partials/${partial}.html").asFile
+            if (f.isFile()) {
+                attrs.put(key, f.getText('UTF-8'))
+            }
+        }
+    }
+
     private static Map<String, Object> manifestToAttributes(
             File manifestFile, Map guide, Map version, String versionKey) {
         Map<String, Object> attrs = [:]

--- a/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
@@ -20,7 +20,8 @@ package website.gradle
 
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
-
+import java.util.regex.Matcher
+import java.util.regex.Pattern
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.yaml.snakeyaml.Yaml
@@ -206,14 +207,8 @@ class RenderGuidesPlugin {
                 String renderTaskName = "renderGuide_${safeName}_${safeVersion}"
                 String stagedRelPath = "staged-guides/${guideName}/${versionKey}"
 
-                // {commondir} resolves relative to each guide's .adoc file,
-                // pointing at the staged copy of guides/common/.
-                attributes.put('commondir', 'common')
-
                 // Stage the per-version source into a working layout that
-                // DocPublisher expects: <staged>/guide/*.adoc + toc.yml. The
-                // shared guides/common/ snippets are copied alongside as
-                // <staged>/guide/common/ so {commondir} resolves cleanly.
+                // DocPublisher expects: <staged>/guide/*.adoc + toc.yml.
                 File commonDirSrc = project.rootProject.layout.projectDirectory
                         .dir('guides/common').asFile
                 project.tasks.register(stageTaskName, org.gradle.api.tasks.Sync) { stage ->
@@ -221,7 +216,6 @@ class RenderGuidesPlugin {
                     stage.description = "Stages ${guideName} v${versionKey} source for the vendored grails-doc renderer"
                     stage.into(project.layout.buildDirectory.dir(stagedRelPath))
                     stage.from(versionDir) {
-                        // Top-level toc.yml is repositioned into guide/ below.
                         exclude 'toc.yml'
                     }
                     File rootToc = new File(versionDir, 'toc.yml')
@@ -230,10 +224,14 @@ class RenderGuidesPlugin {
                             into 'guide'
                         }
                     }
-                    if (commonDirSrc.isDirectory()) {
-                        stage.from(commonDirSrc) {
-                            into 'guide/common'
-                        }
+                    // The vendored grails-doc renderer drives AsciidoctorJ
+                    // without a baseDir, so include::{commondir}/foo.adoc[]
+                    // never resolves. Inline the shared snippets into each
+                    // staged .adoc at config time instead.
+                    stage.doLast {
+                        File guideDir = project.layout.buildDirectory.dir(stagedRelPath).get().asFile
+                        File guideAdocDir = new File(guideDir, 'guide')
+                        inlineCommonIncludes(guideAdocDir, commonDirSrc)
                     }
                 }
 
@@ -343,6 +341,41 @@ class RenderGuidesPlugin {
      * must be scalar.</p>
      */
     @CompileDynamic
+    /**
+     * Replaces {@code include::{commondir}/common-*.adoc[]} directives in
+     * every staged .adoc with the literal contents of the common snippet.
+     * The vendored renderer's AsciidoctorJ wrapper has no baseDir, so
+     * include resolution would otherwise fall through.
+     */
+    @CompileDynamic
+    private static void inlineCommonIncludes(File guideAdocDir, File commonDir) {
+        if (!guideAdocDir.isDirectory() || !commonDir.isDirectory()) {
+            return
+        }
+        Pattern pat = Pattern.compile(/include::\{commondir\}\/(common-[\w\-]+\.adoc)\[\]/)
+        guideAdocDir.eachFileRecurse { File f ->
+            if (!f.isFile() || !f.name.endsWith('.adoc')) return
+            String text = f.getText('UTF-8')
+            Matcher m = pat.matcher(text)
+            if (!m.find()) return
+            StringBuilder out = new StringBuilder()
+            int last = 0
+            m.reset()
+            while (m.find()) {
+                out.append(text, last, m.start())
+                File snippet = new File(commonDir, m.group(1))
+                if (snippet.isFile()) {
+                    out.append(snippet.getText('UTF-8'))
+                } else {
+                    out.append("// missing include: ${m.group(1)}\n".toString())
+                }
+                last = m.end()
+            }
+            out.append(text, last, text.length())
+            f.setText(out.toString(), 'UTF-8')
+        }
+    }
+
     /**
      * Reads the shared chrome partials from {@code templates/partials/} and
      * exposes them as {@code siteHead}, {@code siteHeader}, {@code siteFooter}

--- a/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
@@ -231,7 +231,7 @@ class RenderGuidesPlugin {
                     stage.doLast {
                         File guideDir = project.layout.buildDirectory.dir(stagedRelPath).get().asFile
                         File guideAdocDir = new File(guideDir, 'guide')
-                        inlineCommonIncludes(guideAdocDir, commonDirSrc)
+                        RenderGuidesPlugin.inlineCommonIncludes(guideAdocDir, commonDirSrc)
                     }
                 }
 
@@ -342,13 +342,28 @@ class RenderGuidesPlugin {
      */
     @CompileDynamic
     /**
+     * Reads the shared chrome partials from {@code templates/partials/} and
+     * exposes them as {@code siteHead}, {@code siteHeader}, {@code siteFooter}
+     * so the legacy guide layout can substitute them via Groovy {@code ${...}}.
+     */
+    private static void injectSitePartials(Project project, Map<String, Object> attrs) {
+        ['siteHead': 'site-head', 'siteHeader': 'site-header', 'siteFooter': 'site-footer'].each { key, partial ->
+            File f = project.rootProject.layout.projectDirectory
+                    .file("templates/partials/${partial}.html").asFile
+            if (f.isFile()) {
+                attrs.put(key, f.getText('UTF-8'))
+            }
+        }
+    }
+
+    /**
      * Replaces {@code include::{commondir}/common-*.adoc[]} directives in
      * every staged .adoc with the literal contents of the common snippet.
      * The vendored renderer's AsciidoctorJ wrapper has no baseDir, so
      * include resolution would otherwise fall through.
      */
     @CompileDynamic
-    private static void inlineCommonIncludes(File guideAdocDir, File commonDir) {
+    static void inlineCommonIncludes(File guideAdocDir, File commonDir) {
         if (!guideAdocDir.isDirectory() || !commonDir.isDirectory()) {
             return
         }
@@ -373,21 +388,6 @@ class RenderGuidesPlugin {
             }
             out.append(text, last, text.length())
             f.setText(out.toString(), 'UTF-8')
-        }
-    }
-
-    /**
-     * Reads the shared chrome partials from {@code templates/partials/} and
-     * exposes them as {@code siteHead}, {@code siteHeader}, {@code siteFooter}
-     * so the legacy guide layout can substitute them via Groovy {@code ${...}}.
-     */
-    private static void injectSitePartials(Project project, Map<String, Object> attrs) {
-        ['siteHead': 'site-head', 'siteHeader': 'site-header', 'siteFooter': 'site-footer'].each { key, partial ->
-            File f = project.rootProject.layout.projectDirectory
-                    .file("templates/partials/${partial}.html").asFile
-            if (f.isFile()) {
-                attrs.put(key, f.getText('UTF-8'))
-            }
         }
     }
 

--- a/buildSrc/src/main/groovy/website/gradle/tasks/RenderSiteTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/RenderSiteTask.groovy
@@ -98,6 +98,10 @@ abstract class RenderSiteTask extends GrailsWebsiteTask {
     @OutputDirectory
     abstract DirectoryProperty getOutputDir()
 
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
+    abstract DirectoryProperty getPartialsDir()
+
     static TaskProvider<RenderSiteTask> register(
             Project project,
             GrailsWebsiteExtension siteExt,
@@ -113,6 +117,7 @@ abstract class RenderSiteTask extends GrailsWebsiteTask {
             it.robots.set(siteExt.robots)
             it.title.set(siteExt.title)
             it.url.set(siteExt.url)
+            it.partialsDir.set(project.rootProject.layout.projectDirectory.dir('templates/partials'))
         }
     }
 
@@ -142,7 +147,8 @@ abstract class RenderSiteTask extends GrailsWebsiteTask {
                 metaData,
                 listOfPages,
                 outputDir.dir('dist').get().asFile,
-                document.get().asFile.text
+                document.get().asFile.text,
+                partialsDir.isPresent() ? partialsDir.get().asFile : null
         )
     }
 
@@ -173,7 +179,8 @@ abstract class RenderSiteTask extends GrailsWebsiteTask {
             String> siteMeta,
             List<Page> listOfPages,
             File outputDir,
-            String templateText
+            String templateText,
+            @Nullable File partialsRoot = null
     ) {
         for (def page : listOfPages) {
             def resolvedMetadata = processMetadata(
@@ -182,7 +189,8 @@ abstract class RenderSiteTask extends GrailsWebsiteTask {
             def html = renderHtmlWithTemplateContent(
                     page.content,
                     resolvedMetadata,
-                    templateText
+                    templateText,
+                    partialsRoot
             )
             html = highlightMenu(html, siteMeta, page.path)
             if (page.bodyClassAttr) {
@@ -364,26 +372,30 @@ abstract class RenderSiteTask extends GrailsWebsiteTask {
     static String renderHtmlWithTemplateContent(
             @Nonnull @NotNull String html,
             @Nonnull @NotNull Map<String, String> meta,
-            @NotNull @Nonnull String templateText
+            @NotNull @Nonnull String templateText,
+            @Nullable File partialsRoot = null
     ) {
-        def outputHtml = expandPartials(templateText)
+        def outputHtml = expandPartials(templateText, partialsRoot)
         def result = outputHtml.replace(' data-document>', '>' + html)
         return replaceLineWithMetadata(result, meta)
     }
 
     /**
      * Replace [%PARTIAL:&lt;name&gt;] tokens with the contents of
-     * templates/partials/&lt;name&gt;.html, so shared chrome (header, footer,
+     * &lt;partialsRoot&gt;/&lt;name&gt;.html, so shared chrome (header, footer,
      * head scripts) lives in a single source of truth.
      */
-    static String expandPartials(String templateText) {
+    static String expandPartials(String templateText, @Nullable File partialsRoot) {
+        if (partialsRoot == null) {
+            return templateText
+        }
         Pattern token = Pattern.compile(/\[%PARTIAL:([\w\-]+)\]/)
         Matcher m = token.matcher(templateText)
         StringBuilder out = new StringBuilder()
         int last = 0
         while (m.find()) {
             out.append(templateText, last, m.start())
-            File partial = new File("templates/partials/${m.group(1)}.html")
+            File partial = new File(partialsRoot, "${m.group(1)}.html")
             if (partial.isFile()) {
                 out.append(partial.getText('UTF-8'))
             } else {

--- a/buildSrc/src/main/groovy/website/gradle/tasks/RenderSiteTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/RenderSiteTask.groovy
@@ -21,10 +21,11 @@ package website.gradle.tasks
 import groovy.time.TimeCategory
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
-
 import jakarta.annotation.Nonnull
 import jakarta.annotation.Nullable
 import jakarta.validation.constraints.NotNull
+import java.util.regex.Matcher
+import java.util.regex.Pattern
 
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
@@ -365,9 +366,33 @@ abstract class RenderSiteTask extends GrailsWebsiteTask {
             @Nonnull @NotNull Map<String, String> meta,
             @NotNull @Nonnull String templateText
     ) {
-        def outputHtml = templateText
+        def outputHtml = expandPartials(templateText)
         def result = outputHtml.replace(' data-document>', '>' + html)
         return replaceLineWithMetadata(result, meta)
+    }
+
+    /**
+     * Replace [%PARTIAL:&lt;name&gt;] tokens with the contents of
+     * templates/partials/&lt;name&gt;.html, so shared chrome (header, footer,
+     * head scripts) lives in a single source of truth.
+     */
+    static String expandPartials(String templateText) {
+        Pattern token = Pattern.compile(/\[%PARTIAL:([\w\-]+)\]/)
+        Matcher m = token.matcher(templateText)
+        StringBuilder out = new StringBuilder()
+        int last = 0
+        while (m.find()) {
+            out.append(templateText, last, m.start())
+            File partial = new File("templates/partials/${m.group(1)}.html")
+            if (partial.isFile()) {
+                out.append(partial.getText('UTF-8'))
+            } else {
+                out.append("<!-- missing partial: ${m.group(1)} -->")
+            }
+            last = m.end()
+        }
+        out.append(templateText, last, templateText.length())
+        out.toString()
     }
 
     static String formatDate(String date) {

--- a/guides/resources/style/layout.html
+++ b/guides/resources/style/layout.html
@@ -3,90 +3,19 @@
 <head>
     <title>${title.encodeAsHtml()} | Grails Guides | Apache Grails</title>
     <meta name='description' content='${title.encodeAsHtml()}. ${subtitle?.encodeAsHtml()}'/>
-    <meta name='viewport' content='width=device-width, initial-scale=1'/>
-    <meta charset='UTF-8'/>
-    <link rel='icon' href='https://grails.apache.org/images/favicon.ico'/>
-    <link rel='mask-icon' href='https://grails.apache.org/images/grails-pinned-icon.svg' color='feb672'/>
-    <link rel='alternate' type='application/rss+xml' title='RSS' href='https://grails.apache.org/rss.xml'/>
-    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/screen.css'/>
-    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/plugin.css'/>
+    ${siteHead}
     <link rel='stylesheet' href='${resourcesPath}/css/guide.css'/>
     <link rel='stylesheet' href='${resourcesPath}/css/main.css'/>
-    <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js'></script>
-
-    <!-- Matomo -->
-    <script>
-      var _paq = window._paq = window._paq || [];
-      _paq.push(['setDoNotTrack', true]);
-      _paq.push(['disableCookies']);
-      _paq.push(['trackPageView']);
-      _paq.push(['enableLinkTracking']);
-      (function() {
-        var u = 'https://analytics.apache.org/';
-        _paq.push(['setTrackerUrl', u + 'matomo.php']);
-        _paq.push(['setSiteId', '79']);
-        var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
-        g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
-      })();
-    </script>
-    <!-- End Matomo Code -->
-
-    <script
-        async
-        src="https://widget.kapa.ai/kapa-widget.bundle.js"
-        data-website-id="d804a9f2-51a2-414c-97f7-12f2a1ba4609"
-        data-project-name="Apache Grails"
-        data-project-color="#3F4346"
-        data-font-family="system-ui,-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,Segoe UI,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;"
-        data-project-logo="https://grails.apache.org/images/grails.png"
-        data-modal-override-open-id="ask-ai-input"
-        data-modal-override-open-class="search-input"
-        data-user-analytics-fingerprint-enabled="true"
-        data-modal-title="Apache Grails AI Assistant"
-        data-modal-example-questions-title="Try asking me..."
-        data-modal-example-questions="How does database migration work?,How does Spring Security work?"
-        data-button-text-color="#FBB576"
-        data-modal-header-bg-color="#FFFFFF"
-        data-modal-title-color="#FBB576"
-        data-consent-required="true"></script>
 </head>
 <body class='guide'>
-<header class='main-header'>
-    <div class='content'>
-        <a href='https://grails.apache.org/index.html'><img class='grails-logo' src='https://grails.apache.org/images/grails_logo.svg' alt='Grails Logo'/></a>
-        <a href='javascript:show("top-menus", "show-navigation-link")' id='show-navigation-link'
-           class='mobile align-center'>Show Navigation</a>
-        <div id='top-menus'>
-            <nav class='secondary-menu' id='secondary-menu'>
-                <ul>
-                    <li><a href='https://grails.apache.org/casestudies/index.html'>Case Studies</a></li>
-                    <li><a href='https://grails.apache.org/blog/index.html'>Blog</a></li>
-                    <li><a href='https://grails.apache.org/learning.html'>Learning</a></li>
-                    <li><a href='https://grails.apache.org/community.html'>Community</a></li>
-                    <li><a href='https://grails.apache.org/search.html'>Search</a></li>
-                </ul>
-            </nav>
-            <nav class='main-menu' id='main-menu'>
-                <ul>
-                    <li><a href='https://grails.apache.org/documentation.html'>Documentation</a></li>
-                    <li><a href='https://grails.apache.org/download.html'>Download</a></li>
-                    <li><a href='https://plugins.grails.org'>Plugins</a></li>
-                    <li><a href='https://grails.apache.org/guides'>Guides</a></li>
-                    <li><a href='https://grails.apache.org/faq.html'>FAQ</a></li>
-                    <li><a href='https://grails.apache.org/support.html'>Support</a></li>
-                    <li><a href='https://start.grails.org'>Forge App</a></li>
-                </ul>
-            </nav>
-        </div>
-    </div>
-</header>
+${siteHeader}
 <div class='fullwidth'><article class="guide">
     <aside>
-        <button type="button" class="btn btn-large" onclick="window.location.href=&quot;https://github.com/${githubSlug}&quot;"><img height="15" src="${resourcesPath}/img/github_white.svg" alt="Github"/><span>&nbsp;Get the Code</span></button>
+        <button type="button" class="btn btn-large" onclick="window.location.href=&quot;https://github.com/${githubSlug}&quot;"><img height="15" src="${resourcesPath}/img/github_white.svg" alt="GitHub"/><span>&nbsp;Get the Code</span></button>
         <ul class="githublinks">
-            <li><button type="button" class="btn btn-default" onclick="document.getElementById('github-url').value='git@github.com:${githubSlug}.git'" class="codeButton">SSH</button></li>
-            <li><button type="button" class="btn btn-default" onclick="document.getElementById('github-url').value='https://github.com/${githubSlug}.git'" class="codeButton">HTTPS</button></li>
+            <li><button type="button" class="btn btn-default codeButton" onclick="document.getElementById('github-url').value='git@github.com:${githubSlug}.git'">SSH</button></li>
+            <li><button type="button" class="btn btn-default codeButton" onclick="document.getElementById('github-url').value='https://github.com/${githubSlug}.git'">HTTPS</button></li>
         </ul>
         <div class="input-group">
             <input id="github-url" value="git@github.com:${githubSlug}.git" type="text"/>
@@ -132,38 +61,6 @@
     </header>
     ${content}
 </article></div>
-<footer>
-    <div class='content'>
-        <div class='apache-grails'>
-            <p>Apache Grails is supported by the Apache Software Foundation and the Grails community.</p>
-            <a href='https://apache.org'><img src='https://www.apache.org/img/asf_logo.png' width='200px' alt='Apache Software Foundation'/></a>
-            <p>Apache, Apache Grails, Grails, Groovy, and the ASF logo are either registered trademarks or trademarks of The Apache Software Foundation.</p>
-        </div>
-        <nav class='social-media-nav'>
-            <ul>
-                <li><a href='mailto:dev@grails.apache.org'><img src='https://grails.apache.org/images/email.svg' alt='Email Icon'/></a></li>
-                <li><a href='https://slack.grails.org'><img src='https://grails.apache.org/images/slack.svg' alt='Slack Icon'/></a></li>
-                <li><a href='https://www.youtube.com/@GrailsFramework'><img src='https://grails.apache.org/images/youtube.svg' alt='Youtube Icon'/></a></li>
-                <li><a href='https://bsky.app/profile/grails.apache.org'><img src='https://grails.apache.org/images/bsky.svg' alt='Bluesky Icon'/></a></li>
-                <li><a rel="me" href="https://fosstodon.org/@grails"><img src='https://grails.apache.org/images/mastodont.svg' alt='Mastodont Icon'/></a></li>
-                <li><a href='https://www.linkedin.com/showcase/official-grails/'><img src='https://grails.apache.org/images/linkedin.svg' alt='LinkedIn Icon'/></a></li>
-                <li><a href='https://github.com/apache/grails-core'><img src='https://grails.apache.org/images/github.svg' alt='Github Icon'/></a></li>
-                <li><a href='https://twitter.com/grailsframework'><img src='https://grails.apache.org/images/x-twitter.svg' alt='Twitter Icon'/></a></li>
-            </ul>
-        </nav>
-    </div>
-    <div class='footer-bottom'>
-        <p>© 2005-2026 the Apache Grails project</p>
-        <p>Grails is Open Source:
-            <a href='https://www.apache.org/licenses/'>License</a>,
-            <a href='https://privacy.apache.org/policies/privacy-policy-public.html'>Privacy Policy</a>,
-            <a href='https://www.apache.org/foundation/sponsorship'>Sponsor Apache</a>,
-            <a href='https://www.apache.org/events/current-event'>Events</a>,
-            <a href='https://www.apache.org/security'>Security</a>,
-            <a href='https://www.apache.org/foundation/thanks.html'>Thanks</a>,
-            <a href='https://grails.apache.org/support-schedule.html'>Support Schedule</a>
-        </p>
-    </div>
-</footer>
+${siteFooter}
 </body>
 </html>

--- a/guides/resources/style/layout.html
+++ b/guides/resources/style/layout.html
@@ -1,72 +1,97 @@
 <!DOCTYPE html>
-<html>
-  <head>
-    <meta name='google-site-verification' content='REYQ1_I6HGowAE7LOLVqfQbnKaB4IfFpMlGzMbJj55Q' />
-    <meta name='viewport' content='width=device-width, initial-scale=1' />
-    <link rel='icon' href='/images/favicon.ico' />
-    <link rel='mask-icon' href='//images/grails-pinned-icon.svg' color='feb672' />
-    <meta charset='UTF-8' />
-    <title>${title} | Grails Guides | Grails Framework</title>
-    <meta name='description' content='${title}. ${subtitle}' />
-    <link rel='stylesheet' href='${resourcesPath}/css/main.css' />
-    <link rel='stylesheet' href='${resourcesPath}/css/screen.css' />
+<html lang="en">
+<head>
+    <title>${title.encodeAsHtml()} | Grails Guides | Apache Grails</title>
+    <meta name='description' content='${title.encodeAsHtml()}. ${subtitle?.encodeAsHtml()}'/>
+    <meta name='viewport' content='width=device-width, initial-scale=1'/>
+    <meta charset='UTF-8'/>
+    <link rel='icon' href='https://grails.apache.org/images/favicon.ico'/>
+    <link rel='mask-icon' href='https://grails.apache.org/images/grails-pinned-icon.svg' color='feb672'/>
+    <link rel='alternate' type='application/rss+xml' title='RSS' href='https://grails.apache.org/rss.xml'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/screen.css'/>
+    <link rel='stylesheet' href='https://grails.apache.org/stylesheets/plugin.css'/>
+    <link rel='stylesheet' href='${resourcesPath}/css/guide.css'/>
+    <link rel='stylesheet' href='${resourcesPath}/css/main.css'/>
+    <script src='https://grails.apache.org/javascripts/navigation.js'></script>
     <script src='https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js'></script>
-  </head>
-  <body class='guide'><header class='mainheader'>
-  <div class='content'>
-    <a href='https://grails.apache.org/index.html'><img class='grailslogo' src='/images/grails_logo.svg' alt='Grails Logo' /></a>
-    <a href='javascript:show(&apos;topmenus&apos;, &apos;showNavigationLink&apos;)' id='showNavigationLink' class='mobile align-center'>Show Navigation</a>
-    <div id='topmenus'>
-      <nav class='secondarymenu' id='secondarymenu'><ul>
-  <li>
-    <a href='https://grails.apache.org/learning.html'>Learning</a>
-  </li>
-  <li>
-    <a href='https://grails.apache.org/community.html'>Community</a>
-  </li>
-  <li>
-    <a href='https://grails.apache.org/search.html'>Search</a>
-  </li>
-</ul></nav>
-      <nav class='mainmenu' id='mainmenu'><ul>
-  <li>
-    <a href='https://grails.apache.org/documentation.html'>Documentation</a>
-  </li>
-  <li>
-    <a href='https://grails.apache.org/download.html'>Download</a>
-  </li>
-  <li>
-    <a href='https://plugins.grails.org'>Plugins</a>
-  </li>
-  <li>
-    <a href='https://grails.apache.org/guides'>Guides</a>
-  </li>
-  <li>
-    <a href='https://grails.apache.org/faq.html'>FAQ</a>
-  </li>
-  <li>
-    <a href='https://grails.apache.org/support.html'>Support</a>
-  </li>
-</ul></nav>
+
+    <!-- Matomo -->
+    <script>
+      var _paq = window._paq = window._paq || [];
+      _paq.push(['setDoNotTrack', true]);
+      _paq.push(['disableCookies']);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u = 'https://analytics.apache.org/';
+        _paq.push(['setTrackerUrl', u + 'matomo.php']);
+        _paq.push(['setSiteId', '79']);
+        var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+        g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <!-- End Matomo Code -->
+
+    <script
+        async
+        src="https://widget.kapa.ai/kapa-widget.bundle.js"
+        data-website-id="d804a9f2-51a2-414c-97f7-12f2a1ba4609"
+        data-project-name="Apache Grails"
+        data-project-color="#3F4346"
+        data-font-family="system-ui,-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,Segoe UI,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;"
+        data-project-logo="https://grails.apache.org/images/grails.png"
+        data-modal-override-open-id="ask-ai-input"
+        data-modal-override-open-class="search-input"
+        data-user-analytics-fingerprint-enabled="true"
+        data-modal-title="Apache Grails AI Assistant"
+        data-modal-example-questions-title="Try asking me..."
+        data-modal-example-questions="How does database migration work?,How does Spring Security work?"
+        data-button-text-color="#FBB576"
+        data-modal-header-bg-color="#FFFFFF"
+        data-modal-title-color="#FBB576"
+        data-consent-required="true"></script>
+</head>
+<body class='guide'>
+<header class='main-header'>
+    <div class='content'>
+        <a href='https://grails.apache.org/index.html'><img class='grails-logo' src='https://grails.apache.org/images/grails_logo.svg' alt='Grails Logo'/></a>
+        <a href='javascript:show("top-menus", "show-navigation-link")' id='show-navigation-link'
+           class='mobile align-center'>Show Navigation</a>
+        <div id='top-menus'>
+            <nav class='secondary-menu' id='secondary-menu'>
+                <ul>
+                    <li><a href='https://grails.apache.org/casestudies/index.html'>Case Studies</a></li>
+                    <li><a href='https://grails.apache.org/blog/index.html'>Blog</a></li>
+                    <li><a href='https://grails.apache.org/learning.html'>Learning</a></li>
+                    <li><a href='https://grails.apache.org/community.html'>Community</a></li>
+                    <li><a href='https://grails.apache.org/search.html'>Search</a></li>
+                </ul>
+            </nav>
+            <nav class='main-menu' id='main-menu'>
+                <ul>
+                    <li><a href='https://grails.apache.org/documentation.html'>Documentation</a></li>
+                    <li><a href='https://grails.apache.org/download.html'>Download</a></li>
+                    <li><a href='https://plugins.grails.org'>Plugins</a></li>
+                    <li><a href='https://grails.apache.org/guides'>Guides</a></li>
+                    <li><a href='https://grails.apache.org/faq.html'>FAQ</a></li>
+                    <li><a href='https://grails.apache.org/support.html'>Support</a></li>
+                    <li><a href='https://start.grails.org'>Forge App</a></li>
+                </ul>
+            </nav>
+        </div>
     </div>
-  </div>
-</header><div class='fullwidth'><article class="guide">
+</header>
+<div class='fullwidth'><article class="guide">
     <aside>
-        <a href="https://travis-ci.org/${githubSlug}"><img src="https://travis-ci.org/${githubSlug}.svg?branch=master"></a>
-
-        <button type="button" class="btn btn-large" onclick="window.location.href=&quot;https://github.com/${githubSlug}&quot;"><img height="15" src="../img/github_white.svg" alt="Github"/><span>&nbsp;Get the Code</span></button>
-
-
+        <button type="button" class="btn btn-large" onclick="window.location.href=&quot;https://github.com/${githubSlug}&quot;"><img height="15" src="${resourcesPath}/img/github_white.svg" alt="Github"/><span>&nbsp;Get the Code</span></button>
         <ul class="githublinks">
-            <li><button type="button" class="btn btn-default" href="#" onclick="document.getElementById('github-url').value='git@github.com:${githubSlug}.git'" class="codeButton">SSH</button></li>
+            <li><button type="button" class="btn btn-default" onclick="document.getElementById('github-url').value='git@github.com:${githubSlug}.git'" class="codeButton">SSH</button></li>
             <li><button type="button" class="btn btn-default" onclick="document.getElementById('github-url').value='https://github.com/${githubSlug}.git'" class="codeButton">HTTPS</button></li>
         </ul>
         <div class="input-group">
-            <!-- Target -->
-            <input id="github-url" value="git@github.com:${githubSlug}.git" type="text" />
-            <!-- Trigger -->
-            <button type="button" class="clippy btn btn-default" type="button" data-clipboard-target="#github-url">
-                <img width="13" src="../img/clippy.svg" alt="Copy to clipboard">
+            <input id="github-url" value="git@github.com:${githubSlug}.git" type="text"/>
+            <button type="button" class="clippy btn btn-default" data-clipboard-target="#github-url">
+                <img width="13" src="${resourcesPath}/img/clippy.svg" alt="Copy to clipboard">
             </button>
         </div>
         <script>var clipboard = new Clipboard('.clippy');</script>
@@ -95,7 +120,7 @@
             sectionWriter.call(0, topSection, topSection, i + 1)
             }
             %>
-            <div style="clear:both" ></div>
+            <div style="clear:both"></div>
         </div>
         <% } %>
     </aside>
@@ -106,66 +131,39 @@
         <p><strong>Grails Version:</strong> ${grailsVersion}</p>
     </header>
     ${content}
-</article></div><footer>
-  <div class='content'>
-    <div class='ocihometograils'>
-      <span>Sponsored by</span>
-      <a href='https://objectcomputing.com/products/grails/'><img class='' src='/images/oci_home_to_grails.svg' alt='Object Computing - Home to Grails' width='300px' /></a>
+</article></div>
+<footer>
+    <div class='content'>
+        <div class='apache-grails'>
+            <p>Apache Grails is supported by the Apache Software Foundation and the Grails community.</p>
+            <a href='https://apache.org'><img src='https://www.apache.org/img/asf_logo.png' width='200px' alt='Apache Software Foundation'/></a>
+            <p>Apache, Apache Grails, Grails, Groovy, and the ASF logo are either registered trademarks or trademarks of The Apache Software Foundation.</p>
+        </div>
+        <nav class='social-media-nav'>
+            <ul>
+                <li><a href='mailto:dev@grails.apache.org'><img src='https://grails.apache.org/images/email.svg' alt='Email Icon'/></a></li>
+                <li><a href='https://slack.grails.org'><img src='https://grails.apache.org/images/slack.svg' alt='Slack Icon'/></a></li>
+                <li><a href='https://www.youtube.com/@GrailsFramework'><img src='https://grails.apache.org/images/youtube.svg' alt='Youtube Icon'/></a></li>
+                <li><a href='https://bsky.app/profile/grails.apache.org'><img src='https://grails.apache.org/images/bsky.svg' alt='Bluesky Icon'/></a></li>
+                <li><a rel="me" href="https://fosstodon.org/@grails"><img src='https://grails.apache.org/images/mastodont.svg' alt='Mastodont Icon'/></a></li>
+                <li><a href='https://www.linkedin.com/showcase/official-grails/'><img src='https://grails.apache.org/images/linkedin.svg' alt='LinkedIn Icon'/></a></li>
+                <li><a href='https://github.com/apache/grails-core'><img src='https://grails.apache.org/images/github.svg' alt='Github Icon'/></a></li>
+                <li><a href='https://twitter.com/grailsframework'><img src='https://grails.apache.org/images/x-twitter.svg' alt='Twitter Icon'/></a></li>
+            </ul>
+        </nav>
     </div>
-    <nav class='socialmedianav'><ul>
-  <li>
-    <a href='https://slack.grails.org'><img class='' src='/images/slack.svg' alt='Slack Icon' /></a>
-  </li>
-  <li>
-    <a href='https://www.youtube.com/watch?v=XnRNfDGkBVg&amp;list=PLI74De5M9T73uH3WilDCePP2qfSDpMaGu'><img class='' src='/images/youtube.svg' alt='Youtube Icon' /></a>
-  </li>
-  <li>
-    <a href='https://www.linkedin.com/groups/39757'><img class='' src='/images/linkedin.svg' alt='LinkedIn Icon' /></a>
-  </li>
-  <li>
-    <a href='https://github.com/grails/'><img class='' src='/images/github.svg' alt='Github Icon' /></a>
-  </li>
-  <li>
-    <a href='https://twitter.com/grailsframework'><img class='' src='/images/twitter.svg' alt='Twitter Icon' /></a>
-  </li>
-</ul></nav>
-    <nav class='partnersnav'><ul>
-  <li>Grails' repositories are hosted by
-    <a href='https://repo.grails.org/'>Artifactory</a>
-  </li>
-  <li>Website hosting provided by
-    <a href='https://aws.amazon.com/'>AWS</a>
-  </li>
-  <li>JetBrains supports Grails with its 
-    <a href='https://www.jetbrains.com/idea/'>IntelliJ IDEA IDE</a>
-  </li>
-  <li>YourKit supports Grails with its 
-    <a href='https://www.yourkit.com/java/profiler/index.jsp'>Java Profiler</a>
-  </li>
-  <li>Grails is Open Source
-    <a href='http://www.apache.org/licenses/LICENSE-2.0.html'>Apache 2 License</a>
-  </li>
-  <li>
-    <a href='https://grails.apache.org/buildstatus.html'>Build Status</a>
-  </li>
-</ul></nav>
-  </div>
-</footer><div>
-  <!-- Matomo -->
-  <script>
-    var _paq = window._paq = window._paq || [];
-    _paq.push(['setDoNotTrack', true]);
-    _paq.push(['disableCookies']);
-    _paq.push(['trackPageView']);
-    _paq.push(['enableLinkTracking']);
-    (function() {
-      var u = 'https://analytics.apache.org/';
-      _paq.push(['setTrackerUrl', u + 'matomo.php']);
-      _paq.push(['setSiteId', '79']);
-      var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
-      g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
-    })();
-  </script>
-  <!-- End Matomo Code -->
-</div></body>
+    <div class='footer-bottom'>
+        <p>© 2005-2026 the Apache Grails project</p>
+        <p>Grails is Open Source:
+            <a href='https://www.apache.org/licenses/'>License</a>,
+            <a href='https://privacy.apache.org/policies/privacy-policy-public.html'>Privacy Policy</a>,
+            <a href='https://www.apache.org/foundation/sponsorship'>Sponsor Apache</a>,
+            <a href='https://www.apache.org/events/current-event'>Events</a>,
+            <a href='https://www.apache.org/security'>Security</a>,
+            <a href='https://www.apache.org/foundation/thanks.html'>Thanks</a>,
+            <a href='https://grails.apache.org/support-schedule.html'>Support Schedule</a>
+        </p>
+    </div>
+</footer>
+</body>
 </html>

--- a/templates/document.html
+++ b/templates/document.html
@@ -6,9 +6,6 @@
     <meta name="description" content="[%description]"/>
     <meta name="date" content="[%date]"/>
     <meta name="robots" content="[%robots]"/>
-    <link rel="alternate" type="application/rss+xml" title="RSS" href="[%url]/rss.xml"/>
-    <meta charset='UTF-8'/>
-    <link rel='icon' href='[%url]/images/favicon.ico'/>
     [%twittercard]
     <meta name='twitter:site' content='@grailsframework'/>
     <meta name='twitter:description' content='[%description]'/>
@@ -19,139 +16,18 @@
     <meta property='og:description' content='[%description]'/>
     <meta property='og:type' content='website'/>
 
-    <meta name='viewport' content='width=device-width, initial-scale=1'/>
-    <link rel='mask-icon' href='[%url]/images/grails-pinned-icon.svg' color='feb672'/>
-    <link rel='stylesheet' href='[%url]/stylesheets/screen.css'/>
-    <link rel='stylesheet' href='[%url]/stylesheets/plugin.css'/>
+    [%PARTIAL:site-head]
+
     <link rel='stylesheet' href='[%url]/stylesheets/paginate.css'/>
-    <script src='[%url]/javascripts/navigation.js'></script>
     <script src='[%url]/javascripts/paginate.js'></script>
     [%HTML header]
     [%CSS]
     [%JAVASCRIPT]
     <script src='[%url]/javascripts/plugins.js'></script>
-
-    <!-- Matomo -->
-    <script>
-      var _paq = window._paq = window._paq || [];
-      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-      _paq.push(['setDoNotTrack', true]);
-      _paq.push(['disableCookies']);
-      _paq.push(['trackPageView']);
-      _paq.push(['enableLinkTracking']);
-      (function() {
-        var u = 'https://analytics.apache.org/';
-        _paq.push(['setTrackerUrl', u + 'matomo.php']);
-        _paq.push(['setSiteId', '79']);
-        var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
-        g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
-      })();
-    </script>
-    <!-- End Matomo Code -->
-
-    <script
-        async
-        src="https://widget.kapa.ai/kapa-widget.bundle.js"
-        data-website-id="d804a9f2-51a2-414c-97f7-12f2a1ba4609"
-        data-project-name="Apache Grails"
-        data-project-color="#3F4346"
-        data-font-family="system-ui,-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,Segoe UI,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;"
-        data-project-logo="https://grails.apache.org/images/grails.png"
-        data-modal-override-open-id="ask-ai-input"
-        data-modal-override-open-class="search-input"
-        data-user-analytics-fingerprint-enabled="true"
-        data-modal-title="Apache Grails AI Assistant"
-        data-modal-example-questions-title="Try asking me..."
-        data-modal-disclaimer="This is a custom LLM for Apache Grails using [documentation](https://docs.grails.org/latest/), [groovy documentation](https://docs.groovy-lang.org/docs/groovy-4.0.28/html/documentation/) [github issues](https://github.com/apache/grails-core/issues) and more.
-
-Companies deploy assistants like this [](https://kapa.ai) on docs via [website widget](https://docs.kapa.ai/integrations/website-widget) (Docker, Reddit), in [support forms](https://docs.kapa.ai/integrations/support-form-deflector) for ticket deflection (Monday.com, Mapbox), or as [an internal assistant](https://docs.kapa.ai/integrations/internal-assistant) with access to private sources."
-        data-modal-example-questions="How does database migration work?,How does Spring Security work?"
-        data-button-text-color="#FBB576"
-        data-modal-header-bg-color="#FFFFFF"
-        data-modal-title-color="#FBB576"
-        data-consent-required="true"
-        data-consent-screen-disclaimer="By clicking &quot;I agree, let&#39;s chat&quot;, you consent to the use of the AI assistant in accordance with kapa.ai&#39;s [Privacy Policy](https://www.kapa.ai/content/privacy-policy). This service uses reCAPTCHA, which requires your consent to Google&#39;s [Privacy Policy](https://policies.google.com/privacy) and [Terms of Service](https://policies.google.com/terms). By proceeding, you explicitly agree to both kapa.ai&#39;s and Google&#39;s privacy policies.">
-    </script>
 </head>
 <body>
-<header class='main-header'>
-    <div class='content'>
-        <a href='[%url]/index.html'><img class='grails-logo' src='[%url]/images/grails_logo.svg' alt='Grails Logo'/></a>
-        <a href='javascript:show("top-menus", "show-navigation-link")' id='show-navigation-link'
-           class='mobile align-center'>Show Navigation</a>
-        <div id='top-menus'>
-            <nav class='secondary-menu' id='secondary-menu'>
-                <ul>
-                    <li><a href='[%url]/casestudies/index.html'>Case Studies</a></li>
-                    <li><a href='[%url]/blog/index.html'>Blog</a></li>
-                    <li><a href='[%url]/learning.html'>Learning</a></li>
-                    <li><a href='[%url]/community.html'>Community</a></li>
-                    <li><a href='[%url]/search.html'>Search</a></li>
-                </ul>
-            </nav>
-            <nav class='main-menu' id='main-menu'>
-                <ul>
-                    <li><a href='[%url]/documentation.html'>Documentation</a></li>
-                    <li><a href='[%url]/download.html'>Download</a></li>
-                    <li><a href='[%url]/plugins.html'>Plugins</a></li>
-                    <li><a href='https://grails.apache.org/guides'>Guides</a></li>
-                    <li><a href='[%url]/faq.html'>FAQ</a></li>
-                    <li><a href='[%url]/support.html'>Support</a></li>
-                    <li><a href='https://start.grails.org'>Forge App</a></li>
-                </ul>
-            </nav>
-        </div>
-    </div>
-</header>
+[%PARTIAL:site-header]
 <article data-document>&nbsp;</article>
-<footer>
-    <div class='content'>
-        <div class='apache-grails'>            
-            <p>Apache Grails is supported by the Apache Software Foundation and the Grails community.</p>
-            <a href='https://apache.org'><img src='https://www.apache.org/img/asf_logo.png' width='200px' alt='Apache Software Foundation'/></a>
-            <p>Apache, Apache Grails, Grails, Groovy, and the ASF logo are either registered trademarks or trademarks of The Apache Software Foundation.</p>
-        </div>
-        <nav class='social-media-nav'>
-            <ul>
-                <li>
-                    <a href='mailto:dev@grails.apache.org'><img src='[%url]/images/email.svg' alt='Email Icon'/></a>
-                </li>
-                <li>
-                    <a href='https://slack.grails.org'><img src='[%url]/images/slack.svg' alt='Slack Icon'/></a>
-                </li>
-                <li>
-                    <a href='https://www.youtube.com/@GrailsFramework'><img src='[%url]/images/youtube.svg' alt='Youtube Icon'/></a>
-                </li>
-                <li>
-                    <a href='https://bsky.app/profile/grails.apache.org'><img src='[%url]/images/bsky.svg' alt='Bluesky Icon'/></a>
-                </li>
-                <li>
-                    <a rel="me" href="https://fosstodon.org/@grails"><img src='[%url]/images/mastodont.svg' alt='Mastodont Icon'/></a>
-                </li>
-                <li>
-                    <a href='https://www.linkedin.com/showcase/official-grails/'><img src='[%url]/images/linkedin.svg' alt='LinkedIn Icon'/></a>
-                </li>
-                <li>
-                    <a href='https://github.com/apache/grails-core'><img src='[%url]/images/github.svg' alt='Github Icon'/></a>
-                </li>
-                <li>
-                    <a href='https://twitter.com/grailsframework'><img src='[%url]/images/x-twitter.svg' alt='Twitter Icon'/></a>
-                </li>
-            </ul>
-        </nav>
-    </div>
-    <div class='footer-bottom'>
-        <p>© 2005-2026 the Apache Grails project</p>
-        <p>Grails is Open Source:
-            <a href='https://www.apache.org/licenses/'>License</a>,
-            <a href='https://privacy.apache.org/policies/privacy-policy-public.html'>Privacy Policy</a>,
-            <a href='https://www.apache.org/foundation/sponsorship'>Sponsor Apache</a>,
-            <a href='https://www.apache.org/events/current-event'>Events</a>,
-            <a href='https://www.apache.org/security'>Security</a>,
-            <a href='https://www.apache.org/foundation/thanks.html'>Thanks</a>,
-            <a href='[%url]/support-schedule.html'>Support Schedule</a>
-        </p>
-    </div>
-</footer>
+[%PARTIAL:site-footer]
 </body>
 </html>

--- a/templates/partials/site-footer.html
+++ b/templates/partials/site-footer.html
@@ -11,9 +11,9 @@
                 <li><a href='https://slack.grails.org'><img src='https://grails.apache.org/images/slack.svg' alt='Slack Icon'/></a></li>
                 <li><a href='https://www.youtube.com/@GrailsFramework'><img src='https://grails.apache.org/images/youtube.svg' alt='Youtube Icon'/></a></li>
                 <li><a href='https://bsky.app/profile/grails.apache.org'><img src='https://grails.apache.org/images/bsky.svg' alt='Bluesky Icon'/></a></li>
-                <li><a rel="me" href="https://fosstodon.org/@grails"><img src='https://grails.apache.org/images/mastodont.svg' alt='Mastodont Icon'/></a></li>
+                <li><a rel="me" href="https://fosstodon.org/@grails"><img src='https://grails.apache.org/images/mastodont.svg' alt='Mastodon Icon'/></a></li>
                 <li><a href='https://www.linkedin.com/showcase/official-grails/'><img src='https://grails.apache.org/images/linkedin.svg' alt='LinkedIn Icon'/></a></li>
-                <li><a href='https://github.com/apache/grails-core'><img src='https://grails.apache.org/images/github.svg' alt='Github Icon'/></a></li>
+                <li><a href='https://github.com/apache/grails-core'><img src='https://grails.apache.org/images/github.svg' alt='GitHub Icon'/></a></li>
                 <li><a href='https://twitter.com/grailsframework'><img src='https://grails.apache.org/images/x-twitter.svg' alt='Twitter Icon'/></a></li>
             </ul>
         </nav>

--- a/templates/partials/site-footer.html
+++ b/templates/partials/site-footer.html
@@ -1,0 +1,33 @@
+<footer>
+    <div class='content'>
+        <div class='apache-grails'>
+            <p>Apache Grails is supported by the Apache Software Foundation and the Grails community.</p>
+            <a href='https://apache.org'><img src='https://www.apache.org/img/asf_logo.png' width='200px' alt='Apache Software Foundation'/></a>
+            <p>Apache, Apache Grails, Grails, Groovy, and the ASF logo are either registered trademarks or trademarks of The Apache Software Foundation.</p>
+        </div>
+        <nav class='social-media-nav'>
+            <ul>
+                <li><a href='mailto:dev@grails.apache.org'><img src='https://grails.apache.org/images/email.svg' alt='Email Icon'/></a></li>
+                <li><a href='https://slack.grails.org'><img src='https://grails.apache.org/images/slack.svg' alt='Slack Icon'/></a></li>
+                <li><a href='https://www.youtube.com/@GrailsFramework'><img src='https://grails.apache.org/images/youtube.svg' alt='Youtube Icon'/></a></li>
+                <li><a href='https://bsky.app/profile/grails.apache.org'><img src='https://grails.apache.org/images/bsky.svg' alt='Bluesky Icon'/></a></li>
+                <li><a rel="me" href="https://fosstodon.org/@grails"><img src='https://grails.apache.org/images/mastodont.svg' alt='Mastodont Icon'/></a></li>
+                <li><a href='https://www.linkedin.com/showcase/official-grails/'><img src='https://grails.apache.org/images/linkedin.svg' alt='LinkedIn Icon'/></a></li>
+                <li><a href='https://github.com/apache/grails-core'><img src='https://grails.apache.org/images/github.svg' alt='Github Icon'/></a></li>
+                <li><a href='https://twitter.com/grailsframework'><img src='https://grails.apache.org/images/x-twitter.svg' alt='Twitter Icon'/></a></li>
+            </ul>
+        </nav>
+    </div>
+    <div class='footer-bottom'>
+        <p>&copy; 2005-2026 the Apache Grails project</p>
+        <p>Grails is Open Source:
+            <a href='https://www.apache.org/licenses/'>License</a>,
+            <a href='https://privacy.apache.org/policies/privacy-policy-public.html'>Privacy Policy</a>,
+            <a href='https://www.apache.org/foundation/sponsorship'>Sponsor Apache</a>,
+            <a href='https://www.apache.org/events/current-event'>Events</a>,
+            <a href='https://www.apache.org/security'>Security</a>,
+            <a href='https://www.apache.org/foundation/thanks.html'>Thanks</a>,
+            <a href='https://grails.apache.org/support-schedule.html'>Support Schedule</a>
+        </p>
+    </div>
+</footer>

--- a/templates/partials/site-head.html
+++ b/templates/partials/site-head.html
@@ -1,0 +1,44 @@
+<meta charset='UTF-8'/>
+<meta name='viewport' content='width=device-width, initial-scale=1'/>
+<link rel='icon' href='https://grails.apache.org/images/favicon.ico'/>
+<link rel='mask-icon' href='https://grails.apache.org/images/grails-pinned-icon.svg' color='feb672'/>
+<link rel='alternate' type='application/rss+xml' title='RSS' href='https://grails.apache.org/rss.xml'/>
+<link rel='stylesheet' href='https://grails.apache.org/stylesheets/screen.css'/>
+<link rel='stylesheet' href='https://grails.apache.org/stylesheets/plugin.css'/>
+<script src='https://grails.apache.org/javascripts/navigation.js'></script>
+
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  _paq.push(['setDoNotTrack', true]);
+  _paq.push(['disableCookies']);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u = 'https://analytics.apache.org/';
+    _paq.push(['setTrackerUrl', u + 'matomo.php']);
+    _paq.push(['setSiteId', '79']);
+    var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+    g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
+  })();
+</script>
+<!-- End Matomo Code -->
+
+<script
+    async
+    src="https://widget.kapa.ai/kapa-widget.bundle.js"
+    data-website-id="d804a9f2-51a2-414c-97f7-12f2a1ba4609"
+    data-project-name="Apache Grails"
+    data-project-color="#3F4346"
+    data-font-family="system-ui,-apple-system,BlinkMacSystemFont,Roboto,Helvetica,Arial,Segoe UI,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;"
+    data-project-logo="https://grails.apache.org/images/grails.png"
+    data-modal-override-open-id="ask-ai-input"
+    data-modal-override-open-class="search-input"
+    data-user-analytics-fingerprint-enabled="true"
+    data-modal-title="Apache Grails AI Assistant"
+    data-modal-example-questions-title="Try asking me..."
+    data-modal-example-questions="How does database migration work?,How does Spring Security work?"
+    data-button-text-color="#FBB576"
+    data-modal-header-bg-color="#FFFFFF"
+    data-modal-title-color="#FBB576"
+    data-consent-required="true"></script>

--- a/templates/partials/site-header.html
+++ b/templates/partials/site-header.html
@@ -1,0 +1,29 @@
+<header class='main-header'>
+    <div class='content'>
+        <a href='https://grails.apache.org/index.html'><img class='grails-logo' src='https://grails.apache.org/images/grails_logo.svg' alt='Grails Logo'/></a>
+        <a href='javascript:show("top-menus", "show-navigation-link")' id='show-navigation-link'
+           class='mobile align-center'>Show Navigation</a>
+        <div id='top-menus'>
+            <nav class='secondary-menu' id='secondary-menu'>
+                <ul>
+                    <li><a href='https://grails.apache.org/casestudies/index.html'>Case Studies</a></li>
+                    <li><a href='https://grails.apache.org/blog/index.html'>Blog</a></li>
+                    <li><a href='https://grails.apache.org/learning.html'>Learning</a></li>
+                    <li><a href='https://grails.apache.org/community.html'>Community</a></li>
+                    <li><a href='https://grails.apache.org/search.html'>Search</a></li>
+                </ul>
+            </nav>
+            <nav class='main-menu' id='main-menu'>
+                <ul>
+                    <li><a href='https://grails.apache.org/documentation.html'>Documentation</a></li>
+                    <li><a href='https://grails.apache.org/download.html'>Download</a></li>
+                    <li><a href='https://plugins.grails.org'>Plugins</a></li>
+                    <li><a href='https://grails.apache.org/guides'>Guides</a></li>
+                    <li><a href='https://grails.apache.org/faq.html'>FAQ</a></li>
+                    <li><a href='https://grails.apache.org/support.html'>Support</a></li>
+                    <li><a href='https://start.grails.org'>Forge App</a></li>
+                </ul>
+            </nav>
+        </div>
+    </div>
+</header>


### PR DESCRIPTION
## Summary

Three concrete fixes in the rendered guide chrome plus a centralization pass so the main site and the guides share a single chrome source of truth. Refs #354.

## Visible fixes

1. **`{commondir}/common-helpWithGrails.adoc` was rendering literally** on guides like `grails-micronaut-kafka/4`. `RenderGuidesPlugin` now sets the `commondir` AsciiDoc attribute and stages `guides/common/` alongside each guide's sources so the include resolver picks up the shared snippets.
2. **Travis CI badge removed** from the per-guide aside in `guides/resources/style/layout.html`.
3. **Guide chrome aligned with the main site**. The legacy `mainheader`/`secondarymenu`/`mainmenu`/Object Computing footer is replaced with the main site's `main-header`/`secondary-menu`/`main-menu`/Apache footer. CSS and analytics now point at `grails.apache.org` resources directly.

## Centralization

New `templates/partials/` directory:

- `site-head.html` - Matomo, kapa.ai, favicon, stylesheets, navigation.js
- `site-header.html` - top nav (Logo, Case Studies, Blog, Learning, Community, Search; Documentation, Download, Plugins, Guides, FAQ, Support, Forge App)
- `site-footer.html` - Apache footer with social-media nav and license/privacy/security links

Both pipelines read the SAME files at render time:

- `RenderSiteTask` expands `[%PARTIAL:<name>]` tokens (new `expandPartials` helper) so `templates/document.html` references the partials.
- `RenderGuidesPlugin` injects the partial contents as Groovy template attributes (`\`, `\`, `\`) so `guides/resources/style/layout.html` substitutes them inline.

Editing any of the three partial files now updates both the main site and every rendered guide on the next publish.

## Local verification

`./gradlew clean build buildGuides buildAllGuides --no-daemon --no-configuration-cache` -> BUILD SUCCESSFUL.

Spot-checked four rendered files for the centralized `main-header` class:

- `build/dist/index.html` -> 1 hit
- `build/dist/guides/index.html` -> 1 hit
- `build/dist/guides/grails-database-migration/6/guide/index.html` -> 1 hit
- `build/dist/guides/creating-your-first-grails-app/6/guide/index.html` -> 1 hit

Travis badge: 0 hits in any of those. `commondir` literal: 0 hits (snippets resolve cleanly).