### PR TITLE
Fix /guides/index.html partial expansion + drop legacy main.css from guide layout (refs #354)

### DIFF
--- a/buildSrc/src/main/groovy/website/gradle/tasks/GuidesTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/GuidesTask.groovy
@@ -128,18 +128,26 @@ abstract class GuidesTask extends GrailsWebsiteTask {
         def f = new File(tempDir, PAGE_NAME_GUIDES)
         def page = pageWithFile(f)
         page.filename = 'index.html'
-        RenderSiteTask.renderPages(meta, [page], distDir, templateText)
+        // Resolve [%PARTIAL:<name>] tokens against the same partial bundle
+        // RenderSiteTask uses, so guides/index.html, tag, and category pages
+        // share the main-site chrome.
+        File partialsRoot = project.rootProject.layout.projectDirectory
+                .dir('templates/partials').asFile
+        File partialsArg = partialsRoot.isDirectory() ? partialsRoot : null
+        RenderSiteTask.renderPages(meta, [page], distDir, templateText, partialsArg)
         RenderSiteTask.renderPages(
                 meta,
                 parseCategoryPages(tempDir),
                 new File(distDir, 'categories').tap { it.mkdirs() },
-                templateText
+                templateText,
+                partialsArg
         )
         RenderSiteTask.renderPages(
                 meta,
                 parseTagsPages(tempDir),
                 new File(distDir, 'tags').tap { it.mkdirs() },
-                templateText
+                templateText,
+                partialsArg
         )
     }
 

--- a/guides/resources/style/layout.html
+++ b/guides/resources/style/layout.html
@@ -5,7 +5,6 @@
     <meta name='description' content='${title.encodeAsHtml()}. ${subtitle?.encodeAsHtml()}'/>
     ${siteHead}
     <link rel='stylesheet' href='${resourcesPath}/css/guide.css'/>
-    <link rel='stylesheet' href='${resourcesPath}/css/main.css'/>
     <script src='${resourcesPath}/js/clipboard.min.js'></script>
 </head>
 <body class='guide'>


### PR DESCRIPTION
## Summary

Three small fixes spotted during a visual review of the live site:

1. **`https://grails.apache.org/guides/index.html` was broken** - the rendered HTML still contained literal `[%PARTIAL:site-head]` etc. tokens because `GuidesTask` calls `RenderSiteTask.renderPages` without passing the partials directory. `GuidesTask` now passes `templates/partials` so the same chrome partials that `RenderSiteTask` uses get expanded for guides/index.html, the tag pages, and the category pages.

2. **Per-guide pages had different fonts than the main site** because the legacy `\/css/main.css` was loaded after the main-site stylesheets and overrode body-level rules. Dropped that link. The companion `guide.css` stays for article-body affordances (TOC, GitHub aside, code blocks).

3. **Live verification** sample at `https://grails.apache.org/guides/grails-tvmlapp/3/guide/index.html` will pick up both fixes on the next publish run.

## Local verification

`
$ ./gradlew clean build buildGuides --rerun-tasks --no-daemon --no-configuration-cache
BUILD SUCCESSFUL

$ # build/dist/guides/index.html
main-header: 1, apache-grails: 1, social-media-nav: 1
PARTIAL:site-head: 0  (token expanded)

$ # build/dist/guides/grails-database-migration/6/guide/index.html
main-header: 1, screen.css: 1, plugin.css: 1, guide.css: 1
main.css: 0  (legacy CSS no longer loaded)
`

Refs #354.