### PR TITLE
Fix broken mailing list links in helpWithGrails common include

### DIFF
--- a/guides/common/common-helpWithGrails.adoc
+++ b/guides/common/common-helpWithGrails.adoc
@@ -3,8 +3,8 @@
 Apache Grails is supported by an active community of contributors and the Apache Software Foundation. If you need help working through a guide, want to discuss the framework, or have run into something that looks like a bug, the channels below are the right place to start.
 
 * https://slack.grails.org[Slack] - real-time conversation with the Apache Grails community.
-* https://lists.apache.org/list.html?dev@grails.apache.org[Developer mailing list] - design discussions and contributor coordination.
-* https://lists.apache.org/list.html?users@grails.apache.org[Users mailing list] - end-user questions and answers.
+* https://lists.apache.org/list.html?dev%40grails.apache.org[Developer mailing list] - design discussions and contributor coordination.
+* https://lists.apache.org/list.html?users%40grails.apache.org[Users mailing list] - end-user questions and answers.
 * https://github.com/apache/grails-core/issues[Issue tracker on GitHub] - file a bug or feature request against the framework.
 
 For Grails plugins, see the matching project on https://github.com/apache?q=grails[the apache org] or the plugin's own GitHub repository.


### PR DESCRIPTION
## Summary

The AsciiDoc renderer's email autolink processor was matching the email addresses inside the `lists.apache.org` URL query strings, mangling the outer URL macro and producing nested anchor tags like:

``html
<a href="https://lists.apache.org/list.html?<a href="mailto:dev@grails.apache.org">dev@grails.apache.org</a>">Developer mailing list</a>
``̀

Visible on every guide's `helpWithGrails` section. Example: https://grails.apache.org/guides/grails-tvmlapp/3/guide/index.html

## Fix

URL-encode the `@` as `%40` in the query string. The lists.apache.org server decodes `%40` back to `@` identically, and AsciiDoc has no email pattern to autolink so the outer URL macro renders cleanly.

## Verification

Direct URL test (post-merge): `https://lists.apache.org/list.html?dev%40grails.apache.org` resolves to the same page as `https://lists.apache.org/list.html?dev@grails.apache.org`.

After merge, the next cron-driven publish run will rebuild every guide and the broken links will be gone everywhere `common-helpWithGrails.adoc` is included.

(refs apache/grails-static-website#354)