### PR TITLE
Render mailing list URLs with literal @ instead of %40

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Repositories under [`https://github.com/grails-guides`](https://github.com/grail
 
 **Contact the PMC via the [community page](https://grails.apache.org/community.html):**
 
-- **Dev mailing list**: subscribe by sending a blank email to [`dev-subscribe@grails.apache.org`](mailto:dev-subscribe@grails.apache.org), then post your request to [`dev@grails.apache.org`](https://lists.apache.org/list.html?dev%40grails.apache.org). Include the proposed guide name, a one-line description, and which Grails major version(s) the sample will target.
+- **Dev mailing list**: subscribe by sending a blank email to [`dev-subscribe@grails.apache.org`](mailto:dev-subscribe@grails.apache.org), then post your request to [`dev@grails.apache.org`](https://lists.apache.org/list.html?dev@grails.apache.org). Include the proposed guide name, a one-line description, and which Grails major version(s) the sample will target.
 - **Slack**: join via [https://slack.grails.org](https://slack.grails.org) and ping the PMC in the appropriate channel.
 
 A PMC member with org-admin access on `grails-guides` will create the repository, set the default branch (the latest `grails<N>` you target), and grant you push access. From there you push your `initial/` (and optionally `complete/`) tree as normal.
@@ -401,5 +401,5 @@ All static assets used by the main site live under [`assets/`](assets/). Assets 
 For broader Grails contribution discussion and questions:
 
 - [Community page](https://grails.apache.org/community.html)
-- [Dev mailing list](https://lists.apache.org/list.html?dev%40grails.apache.org)
+- [Dev mailing list](https://lists.apache.org/list.html?dev@grails.apache.org)
 - [Slack](https://slack.grails.org)

--- a/guides/common/common-helpWithGrails.adoc
+++ b/guides/common/common-helpWithGrails.adoc
@@ -3,8 +3,8 @@
 Apache Grails is supported by an active community of contributors and the Apache Software Foundation. If you need help working through a guide, want to discuss the framework, or have run into something that looks like a bug, the channels below are the right place to start.
 
 * https://slack.grails.org[Slack] - real-time conversation with the Apache Grails community.
-* https://lists.apache.org/list.html?dev%40grails.apache.org[Developer mailing list] - design discussions and contributor coordination.
-* https://lists.apache.org/list.html?users%40grails.apache.org[Users mailing list] - end-user questions and answers.
+* link:++https://lists.apache.org/list.html?dev@grails.apache.org++[Developer mailing list] - design discussions and contributor coordination.
+* link:++https://lists.apache.org/list.html?users@grails.apache.org++[Users mailing list] - end-user questions and answers.
 * https://github.com/apache/grails-core/issues[Issue tracker on GitHub] - file a bug or feature request against the framework.
 
 For Grails plugins, see the matching project on https://github.com/apache?q=grails[the apache org] or the plugin's own GitHub repository.


### PR DESCRIPTION
## Summary

- Mailing list links in `guides/common/common-helpWithGrails.adoc` and `README.md` were rendering with `%40` (URL-encoded `@`) in the user-visible href, e.g. `https://lists.apache.org/list.html?dev%40grails.apache.org`. These now render with a literal `@`.
- Root cause: commit 81f78d1c3f (PR #471) used `%40` as a workaround for Asciidoctor 2.5.13's email autolink processor mangling the outer URL macro into nested anchor tags whenever `user@host` appeared inside an `https://...[text]` target.
- Fix: rewrite the AsciiDoc lines using inline passthrough syntax `link:++URL++[text]` so the email autolink does not run over the URL target, while the rendered href keeps the literal `@`. `README.md` links go back to plain `@` (markdown has no equivalent autolink).

## Verification

Re-rendered `creating-your-first-grails-app/v6` (the include is wired into 116 guide pages). The rendered `helpWithGrails.html` now contains:

```html
<a href=""https://lists.apache.org/list.html?dev@grails.apache.org"">Developer mailing list</a>
<a href=""https://lists.apache.org/list.html?users@grails.apache.org"">Users mailing list</a>
```

No nested `<a>` tags, no `%40`.

```bash
./gradlew renderGuide_creating_your_first_grails_app_6 --rerun-tasks --no-configuration-cache
```

## Files changed

- `guides/common/common-helpWithGrails.adoc` - 2 lines, switch to `link:++URL++[text]` passthrough form.
- `README.md` - 2 lines, `%40` -> `@` in two markdown links.