### PR TITLE
Polish code-block rendering and tighten README contributor flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,17 @@ Sample-app flavour adds `sampleRef`:
 6. Render locally: `./gradlew renderGuide_<safeName>_<N>` (underscores in `<safeName>`) and open `build/dist/guides/<name>/<N>/guide/index.html`.
 7. Open a PR against this repository.
 
+### Worked example: grails-fields-custom-widgets-and-wrappers v8
+
+The most recent guide on the site, [grails-fields-custom-widgets-and-wrappers v8](https://grails.apache.org/guides/grails-fields-custom-widgets-and-wrappers/8/guide/index.html), is a sample-app-flavour Grails 8 guide and a useful concrete reference for new authors. It exercises every part of the workflow described above:
+
+- **Source tree:** [`guides/grails-fields-custom-widgets-and-wrappers/v8/`](guides/grails-fields-custom-widgets-and-wrappers/v8/) - 30+ chapter `.adoc` files under `guide/`, vendored Groovy + GSP source under `snippets/`.
+- **Registry entry:** see the `grails-fields-custom-widgets-and-wrappers` block in [`conf/guides.yml`](conf/guides.yml) - shows the full `versions['8']` block with `sourcePath`, `tags`, `sampleRef` (`repo` + `branch`), and the inline `toc:` mapping that drives the table of contents.
+- **Upstream sample app:** [`grails-guides/grails-fields-custom-widgets-and-wrappers`](https://github.com/grails-guides/grails-fields-custom-widgets-and-wrappers) on the `grails8` branch contains the matching `initial/` and `complete/` trees that the `snippets/` directory was vendored from.
+- **Cross-reference:** chapters reference vendored source via `include::../snippets/<path>[]` directives - see [`guide/manyToOneWidget.adoc`](guides/grails-fields-custom-widgets-and-wrappers/v8/guide/manyToOneWidget.adoc) for a representative example that pulls a `_widget.gsp` template into the rendered page.
+
+Reading the v8 guide's source alongside its rendered output is the fastest way to see how `conf/guides.yml`, the `guide/` AsciiDoc, and the vendored `snippets/` come together.
+
 ### Requesting a sample-app repository
 
 Repositories under [`https://github.com/grails-guides`](https://github.com/grails-guides) are owned and provisioned by the Apache Grails PMC. Sample-app flavour guides need one of these repositories before the guide can ship.

--- a/README.md
+++ b/README.md
@@ -203,12 +203,9 @@ Sample-app flavour adds `sampleRef`:
 
 Repositories under [`https://github.com/grails-guides`](https://github.com/grails-guides) are owned and provisioned by the Apache Grails PMC. Sample-app flavour guides need one of these repositories before the guide can ship.
 
-**Contact the PMC via the [community page](https://grails.apache.org/community.html):**
+Contact the PMC via the [community page](https://grails.apache.org/community.html).
 
-- **Dev mailing list**: subscribe by sending a blank email to [`dev-subscribe@grails.apache.org`](mailto:dev-subscribe@grails.apache.org), then post your request to [`dev@grails.apache.org`](https://lists.apache.org/list.html?dev@grails.apache.org). Include the proposed guide name, a one-line description, and which Grails major version(s) the sample will target.
-- **Slack**: join via [https://slack.grails.org](https://slack.grails.org) and ping the PMC in the appropriate channel.
-
-A PMC member with org-admin access on `grails-guides` will create the repository, set the default branch (the latest `grails<N>` you target), and grant you push access. From there you push your `initial/` (and optionally `complete/`) tree as normal.
+A PMC member with org-admin access on `grails-guides` will create the repository, set the default branch (the latest `grails<N>` you target). Then you will create a PR from your personal GitHub fork.
 
 ### Local validation checklist
 

--- a/buildSrc/src/main/template/css/main.css
+++ b/buildSrc/src/main/template/css/main.css
@@ -1215,3 +1215,67 @@ table.CodeRay td.code>pre{padding:0}
 .CodeRay .delete .delete{color:#800}
 .CodeRay .change .change{color:#66f}
 .CodeRay .head .head{color:#f4f}
+
+/* ---- Code-block + inline-code refinements (apache/grails-static-website) ---- */
+
+/* Inline <code> in narrative paragraphs gets a subtle pill background so it
+   stands out from regular prose. Excludes <code> inside <pre> blocks so the
+   syntax-highlighted listings keep their existing flush layout. */
+p > code,
+li > code,
+td > code,
+dd > code,
+dt > code,
+h1 > code, h2 > code, h3 > code, h4 > code, h5 > code, h6 > code {
+    background: #f3f3f4;
+    padding: 0.12em 0.35em;
+    border-radius: 3px;
+    font-size: 0.92em;
+    color: #c7254e;
+    word-break: break-word;
+}
+
+/* The block-code language label was hover-only on desktop; show it always so
+   readers can see the language without mousing over. Also pin it slightly
+   inside the rounded corner so it doesn't look like it's escaping the box. */
+.listingblock code[data-lang]:before {
+    display: block;
+    top: 0.35rem;
+    right: 0.6rem;
+    padding: 0.05em 0.4em;
+    background: rgba(0, 0, 0, 0.05);
+    border-radius: 3px;
+    letter-spacing: 0.04em;
+}
+
+/* The "filename" caption above each listing block (rendered from the
+   "[source,html]\n.path/to/file"-style title) is currently styled like a
+   floating italic line with no visual connection to the code below. Bind
+   it visually to the listing by giving it a top-rounded gray bar that
+   sits flush against the code block. */
+.listingblock > .title {
+    background: #ebebed;
+    color: #555;
+    font-style: normal;
+    font-family: "Droid Sans Mono", "DejaVu Sans Mono", monospace;
+    font-size: 0.78em;
+    padding: 0.4em 0.9em;
+    border-radius: 4px 4px 0 0;
+    margin-bottom: 0;
+    border-bottom: 1px solid #dcdcde;
+}
+
+/* When a listing has a title, square off the top corners of the pre so the
+   title and code meet seamlessly. */
+.listingblock > .title + .content > pre,
+.listingblock > .title + .content > pre[class] {
+    border-radius: 0 0 4px 4px;
+}
+
+/* Slightly relax horizontal scrolling so long lines don't wrap mid-token. */
+.listingblock pre,
+.listingblock pre[class] {
+    overflow-x: auto;
+    word-wrap: normal;
+    white-space: pre;
+}


### PR DESCRIPTION
## Summary

Two small global changes that affect every guide page on the site.

### Code-block CSS (`buildSrc/src/main/template/css/main.css`)

- **Inline `<code>` in narrative paragraphs** (`p`, `li`, `td`, `dd`, `dt`, `h1`-`h6`) now gets a subtle gray pill background + slight color shift so it stands out from regular prose. Block `<code>` inside `<pre>` is unchanged.
- **The `<code data-lang="...">` chip** on every listing block is now always visible (was hover-only on desktop) and rendered as a small inset chip so it doesn't look like it's escaping the box.
- **The "filename" caption above each listing block** (the `.title` element, e.g. `grails-app/views/_fields/manyToOne/_widget.gsp`) now sits flush against the code as a gray header bar with monospace text, instead of floating italic text disconnected from the block.
- **Listings with a title** get square top corners on the `<pre>` so the title bar and the code meet seamlessly.
- **Long lines** now overflow horizontally instead of word-wrapping mid-token.

### README - Requesting a sample-app repository

- Removed the dev-mailing-list and Slack bullet points (the section already points readers at the [community page](https://grails.apache.org/community.html) one sentence above; the bullets duplicated that).
- Updated the post-provisioning sentence: a PMC member creates the repo and sets the default branch, then the contributor opens a PR from their personal GitHub fork - not pushed directly to `grails-guides/<name>` (which would require write access on the grails-guides org).

## Verification

`./gradlew renderGuide_grails_fields_custom_widgets_and_wrappers_8 --rerun-tasks` builds clean. The new selectors land in `build/dist/guides/.../css/main.css` at lines 1221-1271.

## Companion PR

A separate PR will follow that fixes content errors specific to the v8 grails-fields guide (JDK 21 minimum for Grails 8, switch from `prev-snapshot.grails.org` to `start.grails.org`, drop the curl block + query-string explanation, and fix the table-template chapter which currently documents an unreachable per-class path).