### PR TITLE
Expand [%PARTIAL:...] tokens in plugins, blog, and minutes pages

### DIFF
--- a/buildSrc/src/main/groovy/website/gradle/GrailsWebsiteExtension.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/GrailsWebsiteExtension.groovy
@@ -47,6 +47,7 @@ class GrailsWebsiteExtension {
     final DirectoryProperty minutesDir
     final DirectoryProperty outputDir
     final DirectoryProperty pagesDir
+    final DirectoryProperty partialsDir
     final DirectoryProperty postsDir
 
     final Property<String> description
@@ -95,6 +96,9 @@ class GrailsWebsiteExtension {
 
         pagesDir = objects.directoryProperty()
         pagesDir.convention(layout.projectDirectory.dir('pages'))
+
+        partialsDir = objects.directoryProperty()
+        partialsDir.convention(layout.projectDirectory.dir('templates/partials'))
 
         postsDir = objects.directoryProperty()
         postsDir.convention(layout.projectDirectory.dir('posts'))

--- a/buildSrc/src/main/groovy/website/gradle/tasks/BlogTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/BlogTask.groovy
@@ -106,6 +106,10 @@ abstract class BlogTask extends GrailsWebsiteTask {
 
     @InputDirectory
     @PathSensitive(PathSensitivity.RELATIVE)
+    abstract DirectoryProperty getPartialsDir()
+
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
     abstract DirectoryProperty getPostsDir()
 
     @Input
@@ -133,6 +137,7 @@ abstract class BlogTask extends GrailsWebsiteTask {
             it.document.set(siteExt.template)
             it.keywords.set(siteExt.keywords)
             it.outputDir.set(siteExt.outputDir)
+            it.partialsDir.set(siteExt.partialsDir)
             it.postsDir.set(siteExt.postsDir)
             it.releases.set(siteExt.releases)
             it.robots.set(siteExt.robots)
@@ -163,7 +168,18 @@ abstract class BlogTask extends GrailsWebsiteTask {
                 .sort(false)
         def processed = processPosts(meta, posts)
         def blogOut = outputDir.dir('dist/blog').get().asFile.tap { it.mkdirs() }
-        def templateText = document.get().asFile.text
+        // Expand the [%PARTIAL:...] tokens once up front. The downstream
+        // static helpers (renderPostHtml, renderArchive, renderTags ->
+        // renderCards) all forward this expanded text into
+        // RenderSiteTask.renderHtmlWithTemplateContent without a partialsRoot,
+        // and that helper's internal expandPartials is a no-op when
+        // partialsRoot is null. Without this expansion, every rendered blog
+        // post and the blog index shipped the literal "[%PARTIAL:site-head]"
+        // tokens to production.
+        def templateText = RenderSiteTask.expandPartials(
+                document.get().asFile.text,
+                partialsDir.get().asFile
+        )
 
         renderPosts(meta, processed, blogOut, templateText)
 

--- a/buildSrc/src/main/groovy/website/gradle/tasks/MinutesTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/MinutesTask.groovy
@@ -96,6 +96,10 @@ abstract class MinutesTask extends GrailsWebsiteTask {
     @PathSensitive(PathSensitivity.RELATIVE)
     abstract DirectoryProperty getMinutesDir()
 
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
+    abstract DirectoryProperty getPartialsDir()
+
     @Input
     abstract Property<String> getAbout()
 
@@ -126,6 +130,7 @@ abstract class MinutesTask extends GrailsWebsiteTask {
             it.keywords.set(siteExt.keywords)
             it.minutesDir.set(siteExt.minutesDir)
             it.outputDir.set(siteExt.outputDir)
+            it.partialsDir.set(siteExt.partialsDir)
             it.releases.set(siteExt.releases)
             it.robots.set(siteExt.robots)
             it.title.set(siteExt.title)
@@ -147,24 +152,33 @@ abstract class MinutesTask extends GrailsWebsiteTask {
                         .collect {"<option>$it</option>" }
                         .join(' ')
         )
+        // Expand the [%PARTIAL:...] tokens once up front. The downstream
+        // static helpers (renderMinutesHtml, renderArchive) all forward
+        // this expanded text into RenderSiteTask.renderHtmlWithTemplateContent
+        // without a partialsRoot, and that helper's internal expandPartials
+        // is a no-op when partialsRoot is null. Without this expansion,
+        // every rendered minutes page shipped the literal
+        // "[%PARTIAL:site-head]" tokens to production.
+        def templateText = RenderSiteTask.expandPartials(
+                document.get().asFile.text,
+                partialsDir.get().asFile
+        )
         // Output path lives under build/dist/ alongside every other rendered
         // page (BlogTask emits to outputDir.dir('dist/blog'), RenderSiteTask
         // emits to outputDir.dir('dist'), the genHtaccess / genSitemap /
         // genPlugins tasks all live under build/dist/). The publish workflow
         // only ships build/dist/ to the asf-site-production branch, so the
-        // previous output path 'foundation/minutes' (which resolves to
-        // build/foundation/minutes/) never reached production at all and
-        // the live foundation/minutes pages went stale from the moment this
-        // task started writing somewhere outside dist/. The downstream
-        // renderRss call uses outputDir.parentFile + RSS_FILE, which
-        // correspondingly moves from build/foundation/minutes.xml to
+        // previous output path 'foundation/minutes' (which resolved to
+        // build/foundation/minutes/) never reached production at all.
+        // The downstream renderRss call uses outputDir.parentFile + RSS_FILE,
+        // which correspondingly moves from build/foundation/minutes.xml to
         // build/dist/foundation/minutes.xml, lining up with how BlogTask
         // emits build/dist/rss.xml.
         renderMinutes(
                 meta,
                 processMinutes(meta, parseMinutes(minutesDir.get().asFile).sort(false)),
                 outputDir.dir('dist/foundation/minutes').get().asFile.tap { it.mkdirs() },
-                document.get().asFile.text
+                templateText
         )
         fileSystemOperations.copy { CopySpec copy ->
             copy.from(assetsDir.dir('bgimages'))

--- a/buildSrc/src/main/groovy/website/gradle/tasks/PluginsTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/PluginsTask.groovy
@@ -38,6 +38,7 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
@@ -69,6 +70,10 @@ abstract class PluginsTask extends GrailsWebsiteTask {
     @PathSensitive(PathSensitivity.RELATIVE)
     abstract RegularFileProperty getDocument()
 
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
+    abstract DirectoryProperty getPartialsDir()
+
     @Input
     abstract ListProperty<String> getKeywords()
 
@@ -86,6 +91,7 @@ abstract class PluginsTask extends GrailsWebsiteTask {
         project.tasks.register(name, PluginsTask) {
             it.document.set(siteExt.template)
             it.outputDir.set(siteExt.outputDir)
+            it.partialsDir.set(siteExt.partialsDir)
             it.url.set(siteExt.url)
         }
     }
@@ -106,7 +112,18 @@ abstract class PluginsTask extends GrailsWebsiteTask {
         def resolvedMetadata = RenderSiteTask.processMetadata(metadata)
         def result = new JsonSlurper().parse(GRAILS_PLUGINS_JSON.toURL()) as List<Object>
         def plugins = pluginsFromJson(result)
-        renderHtml(plugins, document.get().asFile.text, resolvedMetadata, 'plugins.html')
+        // Expand the [%PARTIAL:site-head] / [%PARTIAL:site-header] /
+        // [%PARTIAL:site-footer] tokens once up front. Downstream static
+        // helpers all forward this expanded template text into
+        // RenderSiteTask.renderHtmlWithTemplateContent without a partialsRoot,
+        // and the second expandPartials pass inside that helper is a no-op
+        // when partialsRoot is null. Without this, the rendered plugins.html
+        // shipped the literal "[%PARTIAL:site-head]" tokens to production.
+        def expandedTemplate = RenderSiteTask.expandPartials(
+                document.get().asFile.text,
+                partialsDir.get().asFile
+        )
+        renderHtml(plugins, expandedTemplate, resolvedMetadata, 'plugins.html')
     }
 
     void renderHtml(List<Plugin> plugins, String templateText, Map<String, String> metadata, String fileName) {

--- a/buildSrc/src/main/groovy/website/gradle/tasks/RenderSiteTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/RenderSiteTask.groovy
@@ -117,7 +117,7 @@ abstract class RenderSiteTask extends GrailsWebsiteTask {
             it.robots.set(siteExt.robots)
             it.title.set(siteExt.title)
             it.url.set(siteExt.url)
-            it.partialsDir.set(project.rootProject.layout.projectDirectory.dir('templates/partials'))
+            it.partialsDir.set(siteExt.partialsDir)
         }
     }
 


### PR DESCRIPTION
## Summary

`https://grails.apache.org/plugins.html` ships with literal `[%PARTIAL:site-head]`, `[%PARTIAL:site-header]`, and `[%PARTIAL:site-footer]` tokens in the rendered HTML, so the page renders without the shared site chrome (top nav, header bar, footer). The same defect affects every blog post, blog tag page, blog index, plugins-tags page, plugins-owners page, and (where they ship at all) minutes pages.

## Root cause

`templates/document.html` embeds the shared chrome via three placeholders:

```html
[%PARTIAL:site-head]
[%PARTIAL:site-header]
[%PARTIAL:site-footer]
```

Substitution is centralised in `RenderSiteTask.renderHtmlWithTemplateContent`, which delegates to `expandPartials(templateText, partialsRoot)`. The latter is a no-op when `partialsRoot` is `null`. `RenderSiteTask` itself wires the partials directory through to its task input and passes it on every call, so `pages/*.html` (`index.html`, `community.html`, `download.html`, `faq.html`, `support.html`, ...) render correctly.

`PluginsTask`, `BlogTask`, and `MinutesTask` all call `renderHtmlWithTemplateContent` with **only three arguments**, so `partialsRoot` defaults to `null` and the `[%PARTIAL:...]` tokens ship to production verbatim.

## Fix

Three small steps, mostly mechanical:

- Add a `partialsDir` directory property to `GrailsWebsiteExtension`, conventioned to `templates/partials` so all task wirings agree on a single source of truth instead of hardcoding the path per task.
- Update `RenderSiteTask` to source its existing `partialsDir` task input from the extension rather than the hardcoded path.
- Add the same `@InputDirectory partialsDir` task input to `PluginsTask`, `BlogTask`, and `MinutesTask`. Wire it from `siteExt.partialsDir` in each `register()` method, and expand the partials once at the top of each `@TaskAction` before the template text reaches the static rendering helpers.

The static rendering helpers keep their existing `String templateText` signatures; they just receive a pre-expanded version. Inside `renderHtmlWithTemplateContent`, the second `expandPartials` pass with `partialsRoot=null` is a no-op, so behaviour is unchanged for any code path that already worked.

## Verification

```bash
./gradlew clean build --no-configuration-cache
```

- `502` `.html` files in `build/dist/` scanned: **`0` unresolved `[%PARTIAL:...]` tokens** (was 364+ tokens across `plugins.html`, `blog/index.html`, `blog/tag/*.html`, `plugins/tags/*.html`, `plugins/owners/*.html` on the live site before this fix).
- Spot checks of `plugins.html`, `blog/index.html`, `blog/tag/groovy.html`, `plugins/tags/rest.html`, `plugins/owners/virtualdogbert.html`, and the unchanged-pipeline pages `index.html` / `community.html` / `download.html` / `faq.html` / `support.html` all show the `main-header` / `secondary-menu` chrome rendering, with no literal `[%PARTIAL:...]` text in the output.
- Visual verification via Playwright on `plugins.html` and `blog/index.html`: full Grails chrome, working top nav, "Blog" / "Plugins" tab highlighted in the secondary nav, page body renders correctly.
- `lsp_diagnostics` clean on all five touched files. The two pre-existing warnings on `assets/stylesheets/screen.css` (unrelated) come from this branch's parent and predate this PR.

## Out of scope

- `364` unresolved `[%ogurl]` tokens remain on `plugins.html` and the `blog/*` / `blog/tag/*` set; that is a pre-existing distinct bug (`PluginsTask` and the `BlogTask` archive/tag paths never set the `ogurl` metadata key) and is already shipping on the live site today. Will ship in a follow-up.
- `MinutesTask` currently emits to `build/foundation/minutes/` rather than `build/dist/foundation/minutes/`, so the rendered minutes pages don't reach production through the publish workflow at all. That is also a separate pre-existing bug and is left untouched here. The partials fix in this PR makes the locally-rendered minutes pages render correctly when the output-path bug is later resolved.
