### PR TITLE
Set [%ogurl] metadata on plugins, blog-archive, blog-tag, and minutes pages

### DIFF
--- a/buildSrc/src/main/groovy/website/gradle/tasks/BlogTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/BlogTask.groovy
@@ -359,6 +359,10 @@ abstract class BlogTask extends GrailsWebsiteTask {
                     tagCards,
                     new LinkedHashMap(meta).tap {
                         it.title = tag.toUpperCase() + ' | Blog | Grails Framework'
+                        // Per-tag Open Graph URL. Without this the [%ogurl]
+                        // token in templates/document.html ships verbatim on
+                        // every blog/tag/<tag>.html page.
+                        it.ogurl = "${it.url}/$BLOG/$TAG/${tag}.html".toString()
                     },
                     templateText,
                     renderTagTitle(tag)
@@ -407,6 +411,11 @@ abstract class BlogTask extends GrailsWebsiteTask {
     ) {
         def meta = RenderSiteTask.processMetadata(siteMeta).tap {
             it.title = 'Blog | Grails Framework'
+            // [%ogurl] is the per-page Open Graph URL token in
+            // templates/document.html. The blog archive index lives at
+            // <siteUrl>/blog/index.html; without this the rendered HTML
+            // shipped the literal [%ogurl] in the og:url meta tag.
+            it.ogurl = "${it.url}/$BLOG/$INDEX".toString()
         }
         def html = cardsHtml(postCards)
         html = RenderSiteTask.renderHtmlWithTemplateContent(html, meta, templateText)

--- a/buildSrc/src/main/groovy/website/gradle/tasks/MinutesTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/MinutesTask.groovy
@@ -213,6 +213,10 @@ abstract class MinutesTask extends GrailsWebsiteTask {
 
         def html = writer.toString()
         def metadata = htmlMinutes.metadata.toMap()
+        // Per-page Open Graph URL. Without this the [%ogurl] token in
+        // templates/document.html ships verbatim on every rendered minutes
+        // page. minutesLink() resolves to "<siteUrl>/foundation/minutes/<path>".
+        metadata['ogurl'] = minutesLink(htmlMinutes)
         html = RenderSiteTask.renderHtmlWithTemplateContent(html, metadata, templateText)
         html = RenderSiteTask.highlightMenu(html, metadata, htmlMinutes.path)
         metadata['bodyClassAttr'] = metadata['bodyClassAttr'] ?: 'foundation minutes'
@@ -319,6 +323,12 @@ abstract class MinutesTask extends GrailsWebsiteTask {
         def html = cardsHtml(minuteCards.toList())
         def resolvedMetadata = RenderSiteTask.processMetadata(siteMeta).tap {
             it.title = 'Foundation | Grails Framework'
+            // [%ogurl] is the per-page Open Graph URL token in
+            // templates/document.html. The minutes archive lives at
+            // <siteUrl>/foundation/minutes/index.html; without this the
+            // rendered HTML shipped the literal [%ogurl] in the og:url
+            // meta tag.
+            it.ogurl = "${it.url}/$MINUTES/$INDEX".toString()
         }
         html = RenderSiteTask.renderHtmlWithTemplateContent(html, resolvedMetadata, templateText)
         html = RenderSiteTask.highlightMenu(html, resolvedMetadata, "/$MINUTES/$INDEX")

--- a/buildSrc/src/main/groovy/website/gradle/tasks/PluginsTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/PluginsTask.groovy
@@ -116,12 +116,25 @@ abstract class PluginsTask extends GrailsWebsiteTask {
         def pluginsTagsDir   = outputDir.dir('dist/plugins/tags').get().asFile.tap { mkdirs() }
         def pluginsOwnersDir = outputDir.dir('dist/plugins/owners').get().asFile.tap { mkdirs() }
 
-        def wrap = { String html -> RenderSiteTask.renderHtmlWithTemplateContent(html, metadata, templateText) }
+        // [%ogurl] is the per-page Open Graph URL token in templates/document.html.
+        // The base metadata map is shared across the main page and every tag/owner
+        // page, so we need to thread a per-page ogurl through wrap() rather than
+        // reusing the same metadata map; otherwise every rendered page would ship
+        // the same og:url meta tag (or, as on the live site today, the literal
+        // [%ogurl] token).
+        def wrap = { String html, String ogurl ->
+            def pageMetadata = new LinkedHashMap<String, String>(metadata)
+            pageMetadata['ogurl'] = ogurl
+            RenderSiteTask.renderHtmlWithTemplateContent(html, pageMetadata, templateText)
+        }
 
         // main plugins page
         new File(distDir, fileName).setText(
                 RenderSiteTask.highlightMenu(
-                        wrap(PluginsPage.mainContent(siteUrl, plugins, 'Grails Plugins', null)),
+                        wrap(
+                                PluginsPage.mainContent(siteUrl, plugins, 'Grails Plugins', null),
+                                "${siteUrl}/plugins.html".toString()
+                        ),
                         metadata,
                         '/plugins.html'
                 ),
@@ -134,7 +147,10 @@ abstract class PluginsTask extends GrailsWebsiteTask {
                 .unique()
                 .each { tag ->
                     new File(pluginsTagsDir, "${tag}.html").setText(
-                            wrap(renderHtmlPagesForTags(siteUrl, plugins, tag)),
+                            wrap(
+                                    renderHtmlPagesForTags(siteUrl, plugins, tag),
+                                    "${siteUrl}/plugins/tags/${tag}.html".toString()
+                            ),
                             'UTF-8'
                     )
                 }
@@ -145,11 +161,12 @@ abstract class PluginsTask extends GrailsWebsiteTask {
                 .findAll { it }
                 .unique()
                 .each { owner ->
-                    new File(
-                            pluginsOwnersDir,
-                            "${owner.replace(' ', '').toLowerCase()}.html"
-                    ).setText(
-                            wrap(renderHtmlPagesForOwners(siteUrl, plugins, owner)),
+                    def ownerSlug = owner.replace(' ', '').toLowerCase()
+                    new File(pluginsOwnersDir, "${ownerSlug}.html").setText(
+                            wrap(
+                                    renderHtmlPagesForOwners(siteUrl, plugins, owner),
+                                    "${siteUrl}/plugins/owners/${ownerSlug}.html".toString()
+                            ),
                             'UTF-8'
                     )
                 }


### PR DESCRIPTION
## Summary

Every page rendered by `PluginsTask`, `BlogTask.renderArchive`, `BlogTask.renderTags`, and `MinutesTask` ships with a literal `[%ogurl]` token in its `<meta property="og:url">` element instead of the actual URL. The defect is visible right now on:

- https://grails.apache.org/plugins.html
- https://grails.apache.org/blog/index.html
- https://grails.apache.org/blog/tag/*.html
- All `plugins/tags/*.html` and `plugins/owners/*.html`
- All minutes pages (whenever the publish workflow next picks them up)

That's 364 affected URLs across the site. The og:url value drives every social share card (Twitter / OpenGraph / LinkedIn previews), so each one currently links to a literal `[%ogurl]` string.

## Root cause

`templates/document.html` embeds `<meta property='og:url' content='[%ogurl]'/>`. `RenderSiteTask.replaceLineWithMetadata` substitutes the token only when the metadata map handed to `renderHtmlWithTemplateContent` contains a non-null `ogurl` key. The fix is purely about populating that key on the rendering paths that forgot it.

For reference, the rendering paths that already set `ogurl` correctly: `RenderSiteTask` (sets it from `siteMeta['url'] + page.path`), `BlogTask.renderPostHtml` (sets it from `postLink(htmlPost)`).

## Changes

### `PluginsTask.renderHtml`

The base metadata map was reused across the main page and every tag/owner page, so we couldn't simply set `ogurl` on it - we need a per-page value. Reshape the `wrap` closure to accept the per-page ogurl, copy the metadata into a fresh `LinkedHashMap`, set `ogurl` on the copy, then render. Three call sites updated:

- `plugins.html` -> `<siteUrl>/plugins.html`
- `plugins/tags/<tag>.html` -> `<siteUrl>/plugins/tags/<tag>.html`
- `plugins/owners/<slug>.html` -> `<siteUrl>/plugins/owners/<slug>.html`

Owner-slug computation is hoisted into a local so the file path and the og:url URL agree.

### `BlogTask.renderArchive`

Set `ogurl` on the resolved metadata (mutating the `.tap{}` block) to `<siteUrl>/blog/index.html`.

### `BlogTask.renderTags`

The per-tag metadata already lives in a `LinkedHashMap.tap{}` block that customises the title; add `ogurl = <siteUrl>/blog/tag/<tag>.html` alongside.

### `MinutesTask.renderArchive`

Set `ogurl` on the resolved metadata to `<siteUrl>/foundation/minutes/index.html`.

### `MinutesTask.renderMinutesHtml`

Set `ogurl` from `minutesLink(htmlMinutes)` (which resolves to `<siteUrl>/foundation/minutes/<htmlMinutes.path>`) before `renderHtmlWithTemplateContent`.

## Verification

```bash
./gradlew clean build --no-configuration-cache
```

- `502` `.html` files in `build/dist/` scanned: **`0` unresolved `[%ogurl]` tokens** (was 364 on the live site before this fix).
- Spot-checked og:url meta tags on the previously-broken pages:

| Page | og:url after fix |
|---|---|
| `plugins.html` | `https://grails.apache.org/plugins.html` |
| `blog/index.html` | `https://grails.apache.org/blog/index.html` |
| `blog/tag/groovy.html` | `https://grails.apache.org/blog/tag/groovy.html` |
| `plugins/tags/rest.html` | `https://grails.apache.org/plugins/tags/rest.html` |
| `plugins/owners/virtualdogbert.html` | `https://grails.apache.org/plugins/owners/virtualdogbert.html` |
| `foundation/minutes/20210321-tab.html` | `https://grails.apache.org/foundation/minutes/20210321-tab.html` |

- Regression check on the always-correct paths: `index.html`, `community.html`, `download.html`, `faq.html`, `support.html`, individual blog posts (`2015-03-01.html`, `2016-04-01-1.html`, etc.) all still emit their pre-existing correct og:url meta tags.
- `lsp_diagnostics` clean on the three changed files.

## Notes

- This PR depends only on master and is independent of #486 (the `[%PARTIAL:...]` expansion fix). The two PRs touch different metadata keys and do not conflict.
- The minutes-pages output-path bug (rendered to `build/foundation/minutes/` instead of `build/dist/foundation/minutes/`) is still a separate pre-existing defect; the ogurl fix here will land on minutes pages whenever that path bug is also fixed.
