### PR TITLE
Move MinutesTask output under build/dist/ so minutes pages reach production

### DIFF
--- a/buildSrc/src/main/groovy/website/gradle/tasks/MinutesTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/MinutesTask.groovy
@@ -147,10 +147,23 @@ abstract class MinutesTask extends GrailsWebsiteTask {
                         .collect {"<option>$it</option>" }
                         .join(' ')
         )
+        // Output path lives under build/dist/ alongside every other rendered
+        // page (BlogTask emits to outputDir.dir('dist/blog'), RenderSiteTask
+        // emits to outputDir.dir('dist'), the genHtaccess / genSitemap /
+        // genPlugins tasks all live under build/dist/). The publish workflow
+        // only ships build/dist/ to the asf-site-production branch, so the
+        // previous output path 'foundation/minutes' (which resolves to
+        // build/foundation/minutes/) never reached production at all and
+        // the live foundation/minutes pages went stale from the moment this
+        // task started writing somewhere outside dist/. The downstream
+        // renderRss call uses outputDir.parentFile + RSS_FILE, which
+        // correspondingly moves from build/foundation/minutes.xml to
+        // build/dist/foundation/minutes.xml, lining up with how BlogTask
+        // emits build/dist/rss.xml.
         renderMinutes(
                 meta,
                 processMinutes(meta, parseMinutes(minutesDir.get().asFile).sort(false)),
-                outputDir.dir('foundation/minutes').get().asFile.tap { it.mkdirs() },
+                outputDir.dir('dist/foundation/minutes').get().asFile.tap { it.mkdirs() },
                 document.get().asFile.text
         )
         fileSystemOperations.copy { CopySpec copy ->


### PR DESCRIPTION
## Summary

`MinutesTask.renderMinutes` writes rendered foundation/minutes pages to `outputDir.dir('foundation/minutes')`, which resolves to `build/foundation/minutes/` because `siteExt.outputDir` is conventioned to the project's build directory. **The publish workflow only ships `build/dist/` to the `asf-site-production` branch**, so anything the build emits outside `build/dist/` is invisible to production. Result: foundation/minutes pages have not received build updates from `./gradlew build` since this divergence was introduced; the live foundation/minutes pages on `grails.apache.org` are stale, rendered by some earlier version of the build that put them in the right place.

## Context

Every other rendering task in this project writes underneath `build/dist/`:

| Task | Output |
|---|---|
| `RenderSiteTask` | `outputDir.dir('dist')` |
| `BlogTask` | `outputDir.dir('dist/blog')` |
| `PluginsTask` | `outputDir.dir('dist')`, `outputDir.dir('dist/plugins/tags')`, `outputDir.dir('dist/plugins/owners')` |
| `BlogTask` (asset copy) | `outputDir.dir('dist/images')` |
| `MinutesTask` (asset copy) | `outputDir.dir('dist/images')` |
| **`MinutesTask` (HTML render)** | **`outputDir.dir('foundation/minutes')` ← the bug** |

## Fix

Change the destination directory from `'foundation/minutes'` to `'dist/foundation/minutes'`. The downstream `renderRss` call uses `outputDir.parentFile` resolved against the same target, so the RSS feed correspondingly moves from `build/foundation/minutes.xml` to `build/dist/foundation/minutes.xml`, lining up with how `BlogTask` emits `build/dist/rss.xml` from `build/dist/blog/`.

## Verification

```bash
./gradlew clean build --no-configuration-cache
```

- `6` `.html` minutes pages appear under `build/dist/foundation/minutes/` (5 individual + 1 index).
- The minutes RSS feed appears at `build/dist/foundation/minutes.xml`.
- The previous `build/foundation/minutes/` tree is gone.
- Regression check: 15 root pages, 125 blog posts, 214 plugins tag pages, 109 plugins owner pages all still render.

## Out of scope

The minutes pages still need PR #486 merged (to expand the `[%PARTIAL:...]` tokens) and PR #487 merged (to populate `[%ogurl]`) before they render with full site chrome and correct social cards. That ordering is fine; **this PR is the prerequisite that makes the pages reach production at all**. Without this fix, the partials and ogurl improvements never ship to live minutes pages.
