### PR TITLE
Render the guides Improve this doc button as a button at all times

### DIFF
--- a/guides/resources/css/guide.css
+++ b/guides/resources/css/guide.css
@@ -275,8 +275,9 @@ body.guide article.guide aside button.btn-large + ul.githublinks + .input-group 
  * AsciiDoc renders a <div class="contribute-btn"><button class="btn btn-default">
  * after every <h1>/<h2>. The legacy treatment was a screaming orange CTA
  * directly under each heading, which competed with the heading itself for
- * attention. Demote it to a subtle right-aligned link with a pencil glyph,
- * GitHub-style. */
+ * attention. Render it as a calm, GitHub-style outlined button that is
+ * visible at rest (subtle background + border) and gains a colour accent
+ * on hover, instead of only revealing button chrome on hover. */
 .contribute-btn {
 	float: right;
 	margin: -28px 0 0 12px;
@@ -285,10 +286,10 @@ body.guide article.guide aside button.btn-large + ul.githublinks + .input-group 
 
 .contribute-btn button.btn,
 .contribute-btn button.btn-default {
-	background: transparent !important;
-	background-color: transparent !important;
+	background: #f6f8fa !important;
+	background-color: #f6f8fa !important;
 	background-image: none !important;
-	border: 1px solid transparent !important;
+	border: 1px solid #d0d7de !important;
 	border-radius: 6px !important;
 	color: #6b7280 !important;
 	font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif !important;
@@ -306,8 +307,8 @@ body.guide article.guide aside button.btn-large + ul.githublinks + .input-group 
 .contribute-btn button.btn:hover,
 .contribute-btn button.btn-default:hover {
 	color: #0969da !important;
-	background-color: #f6f8fa !important;
-	border-color: #d0d7de !important;
+	background-color: #eaeef2 !important;
+	border-color: #afb8c1 !important;
 }
 
 .contribute-btn .fa,


### PR DESCRIPTION
## Summary

- Make the AsciiDoc-emitted "Improve this doc" button on guide pages render as a visible button at rest, instead of only revealing button chrome on hover.
- Default state now uses the surface (`#f6f8fa` background) and border (`#d0d7de`) that PR #485 had reserved for `:hover`. Hover gains a slightly deeper surface (`#eaeef2`) and stronger border (`#afb8c1`) on top of the existing GitHub-blue text accent (`#0969da`), so there is still a clear interaction signal.
- Single file: `guides/resources/css/guide.css` (the stylesheet that `guides/resources/style/layout.html` actually loads for every rendered guide page).

## Why

PR #485 / commit bb0d09ff17 demoted the legacy orange CTA into a calm GitHub-style outlined button - correct direction, but the rest state was set to `background: transparent` / `border: 1px solid transparent`, so the control reads as a plain pencil-glyph link until you hover it. Per user feedback, on guide pages the button should look like a button at all times.

## Verification

- `./gradlew renderGuide_creating_your_first_grails_app_6` - rendered guide picks up the new CSS (37 `.contribute-btn` buttons across the chapters).
- Served `build/dist/` via `jwebserver` and inspected with Playwright. `getComputedStyle(.contribute-btn button)` in the rest state reports `background-color: rgb(246, 248, 250)` (`#f6f8fa`) and `border-color: rgb(208, 215, 222)` (`#d0d7de`), confirming the button surface and border are now present without hover.

## Out of scope

- The legacy orange `.contribute-btn button` rules in `guides/resources/css/screen.css` and `assets/stylesheets/screen.css` are not loaded by guide pages (`layout.html` only links `guide.css`) and are already overridden everywhere else via the `!important` selectors in `guide.css`. Left untouched here.
