### PR TITLE
Bootstrap recordCompanionRelease for new majors and add Grails 8 grails-publish 1.0.0-M1

### DIFF
--- a/.github/workflows/release-companion.yml
+++ b/.github/workflows/release-companion.yml
@@ -11,6 +11,15 @@ on:
       artifact_version:
         description: 'New companion version (e.g. 5.0.2)'
         required: true
+      mirror_directory:
+        description: 'First-time only: sub-path under https://www.apache.org/dyn/closer.lua/grails/ where the artifact distribution lives. Ignored for subsequent bumps.'
+        required: false
+      release_notes_repo:
+        description: 'First-time only: GitHub slug (org/repo) used for the v<version> release-notes link. Ignored for subsequent bumps.'
+        required: false
+      display_name:
+        description: 'First-time only: human-readable label rendered on the downloads page. Ignored for subsequent bumps.'
+        required: false
 jobs:
   release-companion:
     runs-on: ubuntu-latest
@@ -32,7 +41,10 @@ jobs:
           ./gradlew --no-daemon recordCompanionRelease \
             -PgrailsMajor=${{ github.event.inputs.grails_major }} \
             -PartifactId=${{ github.event.inputs.artifact_id }} \
-            -PartifactVersion=${{ github.event.inputs.artifact_version }}
+            -PartifactVersion=${{ github.event.inputs.artifact_version }} \
+            -PmirrorDirectory="${{ github.event.inputs.mirror_directory }}" \
+            -PreleaseNotesRepo="${{ github.event.inputs.release_notes_repo }}" \
+            -PdisplayName="${{ github.event.inputs.display_name }}"
       - name: Commit companion release
         run: |
           git config user.name ${GIT_USER_NAME}

--- a/buildSrc/src/main/groovy/website/gradle/tasks/RecordCompanionReleaseTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/RecordCompanionReleaseTask.groovy
@@ -26,37 +26,50 @@ import org.gradle.api.Project
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 
 /**
- * Bumps the {@code version:} field of an existing companion artifact entry in
+ * Maintains entries in the {@code companionArtifacts:} block of
  * {@code conf/releases.yml}. Companion artifacts (Spring Security, Redis,
  * Quartz, GitHub Actions, Gradle Publish, ...) ship independently of Grails
- * core, so each one has its own release cadence and needs its own bump task.
+ * core, so each one has its own release cadence.
  *
  * <p>Invoked from {@code .github/workflows/release-companion.yml} on a
- * {@code workflow_dispatch}, with three inputs:
- * <pre>
- *   ./gradlew recordCompanionRelease \
- *       -PgrailsMajor=7 \
- *       -PartifactId=grails-redis \
- *       -PartifactVersion=5.0.2
- * </pre>
+ * {@code workflow_dispatch}. The task supports three operations on a single
+ * {@code (grailsMajor, artifactId)} pair, automatically picking the right one
+ * based on what already exists in the file:
  *
- * <p>The task performs a line-based update so existing comments and
- * indentation in {@code releases.yml} are preserved (a YAML round-trip via
- * SnakeYAML would erase them). It looks for the {@code 'N':} block under
- * {@code companionArtifacts:}, then within that block locates the entry whose
- * {@code artifactId:} matches and rewrites the next {@code version:} line.
+ * <ol>
+ *   <li><strong>Bump existing entry</strong> - the artifact is already listed
+ *   under its major. The {@code version:} field is rewritten in place and
+ *   the optional descriptor flags are ignored.
+ *   <pre>
+ *     ./gradlew recordCompanionRelease \
+ *         -PgrailsMajor=7 \
+ *         -PartifactId=grails-redis \
+ *         -PartifactVersion=5.0.2
+ *   </pre></li>
+ *   <li><strong>Add new artifact to an existing major</strong> - the
+ *   {@code 'N':} block exists but does not yet contain this artifactId. A new
+ *   entry is appended to the end of that block. All three descriptor flags
+ *   ({@code -PmirrorDirectory}, {@code -PreleaseNotesRepo},
+ *   {@code -PdisplayName}) are required.</li>
+ *   <li><strong>Bootstrap a brand-new major</strong> - no {@code 'N':} block
+ *   exists yet. A new major block is appended to the end of the
+ *   {@code companionArtifacts:} section (preserving the trailing blank line
+ *   that separates it from {@code coreReleases:}) containing exactly one
+ *   entry. All three descriptor flags are required.</li>
+ * </ol>
  *
- * <p>This task only updates an existing entry. First-time addition of a brand
- * new companion artifact for a major requires a manual edit of
- * {@code conf/releases.yml} (e.g. a one-time PR when a new plugin is
- * provisioned by the PMC), since the schema of a new entry can vary
- * (mirrorDirectory, releaseNotesRepo, displayName all need PMC-supplied
- * values).
+ * <p>The task performs line-based edits so existing comments and indentation
+ * in {@code releases.yml} are preserved (a YAML round-trip via SnakeYAML
+ * would erase them). The descriptor flags are accepted but ignored on the
+ * bump path because changing them mid-major would break URLs that downstream
+ * pages and crawlers may have already indexed - those changes intentionally
+ * require a manual PR.
  */
 @CompileStatic
 abstract class RecordCompanionReleaseTask extends DefaultTask {
@@ -72,6 +85,18 @@ abstract class RecordCompanionReleaseTask extends DefaultTask {
 
     @Input
     abstract Property<String> getArtifactVersion()
+
+    @Input
+    @Optional
+    abstract Property<String> getMirrorDirectory()
+
+    @Input
+    @Optional
+    abstract Property<String> getReleaseNotesRepo()
+
+    @Input
+    @Optional
+    abstract Property<String> getDisplayName()
 
     @OutputFile
     abstract RegularFileProperty getReleasesYaml()
@@ -93,92 +118,178 @@ abstract class RecordCompanionReleaseTask extends DefaultTask {
         }
 
         List<String> lines = yaml.readLines('UTF-8')
-        boolean inCompanionSection = false
-        boolean inMajorSection = false
-        boolean foundArtifact = false
-        boolean updated = false
-        String majorMarker = "'${major}':".toString()
-        String artifactMarker = "artifactId: ${artifact}".toString()
+        Layout layout = scanLayout(lines, major, artifact)
+
+        if (layout.companionHeaderIdx < 0) {
+            throw new GradleException(
+                    "${yaml.name} has no companionArtifacts: section. The schema migration commit added it; ".toString() +
+                            'did the working tree drift?')
+        }
+
+        String mode
+        if (layout.targetArtifactVersionIdx >= 0) {
+            String original = lines[layout.targetArtifactVersionIdx]
+            lines[layout.targetArtifactVersionIdx] =
+                    "${leadingWhitespace(original)}version: '${version}'".toString()
+            mode = 'bump'
+        } else if (layout.targetMajorEndIdx >= 0) {
+            requireDescriptorFlags(major, artifact, false)
+            lines.addAll(layout.targetMajorEndIdx, renderEntry(artifact, version))
+            mode = 'new-artifact'
+        } else {
+            requireDescriptorFlags(major, artifact, true)
+            lines.addAll(layout.companionSectionEndIdx, renderMajorBlock(major, artifact, version))
+            mode = 'new-major'
+        }
+
+        yaml.text = lines.join(System.lineSeparator()) + System.lineSeparator()
+        logger.lifecycle(
+                "Updated companion ${artifact} to ${version} for Grails ${major} in ${yaml.name} (${mode}).".toString())
+    }
+
+    private void requireDescriptorFlags(String major, String artifact, boolean newMajor) {
+        String mirror = mirrorDirectory.getOrElse('').trim()
+        String notes = releaseNotesRepo.getOrElse('').trim()
+        String display = displayName.getOrElse('').trim()
+        List<String> missing = []
+        if (!mirror) missing << '-PmirrorDirectory=<sub-path>'
+        if (!notes) missing << '-PreleaseNotesRepo=<org/repo>'
+        if (!display) missing << '-PdisplayName=<Human Readable Name>'
+        if (missing) {
+            String context = newMajor
+                    ? "no '${major}': block exists yet under companionArtifacts:".toString()
+                    : "artifactId=${artifact} is not yet listed under '${major}':".toString()
+            throw new GradleException(
+                    "First-time entry: ${context}. Required descriptor flags missing: ${missing.join(', ')}. ".toString() +
+                            'Pass all three so the new entry can be rendered (mirror URL, release-notes link, display name).')
+        }
+    }
+
+    private List<String> renderEntry(String artifact, String version) {
+        return [
+                "    - artifactId: ${artifact}".toString(),
+                "      version: '${version}'".toString(),
+                "      mirrorDirectory: ${mirrorDirectory.get().trim()}".toString(),
+                "      releaseNotesRepo: ${releaseNotesRepo.get().trim()}".toString(),
+                "      displayName: ${displayName.get().trim()}".toString(),
+        ]
+    }
+
+    private List<String> renderMajorBlock(String major, String artifact, String version) {
+        List<String> block = ["  '${major}':".toString()] as List<String>
+        block.addAll(renderEntry(artifact, version))
+        return block
+    }
+
+    private static String leadingWhitespace(String line) {
+        StringBuilder ws = new StringBuilder()
+        for (int j = 0; j < line.length(); j++) {
+            char ch = line.charAt(j)
+            if (ch == ' ' as char || ch == '\t' as char) {
+                ws.append(ch)
+            } else {
+                break
+            }
+        }
+        return ws.toString()
+    }
+
+    private static Layout scanLayout(List<String> lines, String targetMajor, String targetArtifact) {
+        Layout layout = new Layout()
+        String majorMarker = "'${targetMajor}':".toString()
+        String artifactMarker = "artifactId: ${targetArtifact}".toString()
+        boolean inCompanion = false
+        boolean inTargetMajor = false
+        boolean inTargetArtifact = false
 
         for (int i = 0; i < lines.size(); i++) {
             String line = lines[i]
             String trimmed = line.trim()
-            // Strip the YAML list-item prefix "- " so we can compare against
-            // an artifactId without worrying about which entry happens to be
-            // the first (sequence-bullet-bearing) one in the major's block.
             String normalized = trimmed.startsWith('- ') ? trimmed.substring(2) : trimmed
 
-            if (trimmed == 'companionArtifacts:' || trimmed.startsWith('companionArtifacts:')) {
-                inCompanionSection = true
-                continue
-            }
-
-            // Leaving the companionArtifacts: section once we hit another
-            // top-level key (a non-blank line with no leading whitespace).
-            if (inCompanionSection && trimmed && !line.startsWith(' ') && !line.startsWith('\t')
-                    && !trimmed.startsWith('#')) {
-                inCompanionSection = false
-                inMajorSection = false
-            }
-
-            if (inCompanionSection && trimmed.startsWith(majorMarker)) {
-                inMajorSection = true
-                continue
-            }
-
-            // Within companionArtifacts, hitting another quoted single-segment
-            // major key (e.g. "'8':") means we've left our major.
-            if (inMajorSection && trimmed ==~ /^'\d+':$/ && trimmed != majorMarker) {
-                inMajorSection = false
-            }
-
-            if (inMajorSection && !foundArtifact && normalized == artifactMarker) {
-                foundArtifact = true
-                continue
-            }
-
-            if (foundArtifact && trimmed.startsWith('version:')) {
-                // Preserve the original indentation; rewrite only the value
-                // and (re-apply) single-quote wrapping for consistency with
-                // the rest of the companion entries written by the previous
-                // commit's data migration.
-                String leadingWs = ''
-                for (int j = 0; j < line.length(); j++) {
-                    char ch = line.charAt(j)
-                    if (ch == ' ' as char || ch == '\t' as char) {
-                        leadingWs += ch
-                    } else {
-                        break
-                    }
+            if (!inCompanion) {
+                if (trimmed == 'companionArtifacts:' || trimmed.startsWith('companionArtifacts:')) {
+                    inCompanion = true
+                    layout.companionHeaderIdx = i
                 }
-                lines[i] = "${leadingWs}version: '${version}'".toString()
-                updated = true
-                break
+                continue
+            }
+
+            boolean isTopLevelKey = trimmed && !line.startsWith(' ') && !line.startsWith('\t') && !trimmed.startsWith('#')
+            if (isTopLevelKey) {
+                int sectionEnd = trimToLastMeaningfulLine(lines, i)
+                if (inTargetMajor && layout.targetMajorEndIdx < 0) {
+                    layout.targetMajorEndIdx = sectionEnd
+                }
+                layout.companionSectionEndIdx = sectionEnd
+                return layout
+            }
+
+            if (trimmed ==~ /^'\d+':$/) {
+                if (inTargetMajor && layout.targetMajorEndIdx < 0) {
+                    layout.targetMajorEndIdx = trimToLastMeaningfulLine(lines, i)
+                }
+                inTargetMajor = (trimmed == majorMarker)
+                inTargetArtifact = false
+                continue
+            }
+
+            if (inTargetMajor && normalized == artifactMarker) {
+                inTargetArtifact = true
+                continue
+            }
+            if (inTargetMajor && normalized.startsWith('artifactId: ')) {
+                inTargetArtifact = false
+                continue
+            }
+            if (inTargetArtifact && trimmed.startsWith('version:') && layout.targetArtifactVersionIdx < 0) {
+                layout.targetArtifactVersionIdx = i
             }
         }
 
-        if (!updated) {
-            throw new GradleException(
-                    "Could not find companionArtifact entry artifactId=${artifact} under Grails major '${major}' in ${yaml.name}. ".toString() +
-                            'For a brand-new companion artifact, add the entry to conf/releases.yml manually first.')
+        if (layout.companionHeaderIdx >= 0 && layout.companionSectionEndIdx < 0) {
+            layout.companionSectionEndIdx = trimToLastMeaningfulLine(lines, lines.size())
         }
+        if (inTargetMajor && layout.targetMajorEndIdx < 0) {
+            layout.targetMajorEndIdx = layout.companionSectionEndIdx
+        }
+        return layout
+    }
 
-        yaml.text = lines.join(System.lineSeparator()) + System.lineSeparator()
-        logger.lifecycle("Updated companion ${artifact} to ${version} for Grails ${major} in ${yaml.name}.")
+    private static int trimToLastMeaningfulLine(List<String> lines, int upperExclusive) {
+        int idx = upperExclusive
+        while (idx > 0 && lines[idx - 1].trim().isEmpty()) {
+            idx--
+        }
+        return idx
+    }
+
+    private static class Layout {
+        int companionHeaderIdx = -1
+        int companionSectionEndIdx = -1
+        int targetMajorEndIdx = -1
+        int targetArtifactVersionIdx = -1
     }
 
     static TaskProvider<RecordCompanionReleaseTask> register(Project project) {
         project.tasks.register(NAME, RecordCompanionReleaseTask) { task ->
             task.group = GROUP
             task.description =
-                    'Bump a companion artifact version in conf/releases.yml. ' +
-                            'Pass via -PgrailsMajor=N -PartifactId=name -PartifactVersion=X.Y.Z.'
+                    'Maintain a companion artifact entry in conf/releases.yml. ' +
+                            'Required: -PgrailsMajor=N -PartifactId=name -PartifactVersion=X.Y.Z. ' +
+                            'For first-time entries also pass: -PmirrorDirectory=path -PreleaseNotesRepo=org/repo -PdisplayName=Label.'
             task.grailsMajor.set(
                     project.providers.gradleProperty('grailsMajor').orElse(''))
             task.artifactId.set(
                     project.providers.gradleProperty('artifactId').orElse(''))
             task.artifactVersion.set(
                     project.providers.gradleProperty('artifactVersion').orElse(''))
+            task.mirrorDirectory.set(
+                    project.providers.gradleProperty('mirrorDirectory').orElse(''))
+            task.releaseNotesRepo.set(
+                    project.providers.gradleProperty('releaseNotesRepo').orElse(''))
+            task.displayName.set(
+                    project.providers.gradleProperty('displayName').orElse(''))
             task.releasesYaml.set(
                     project.rootProject.layout.projectDirectory.file('conf/releases.yml'))
         }

--- a/buildSrc/src/test/groovy/website/gradle/tasks/RecordCompanionReleaseTaskSpec.groovy
+++ b/buildSrc/src/test/groovy/website/gradle/tasks/RecordCompanionReleaseTaskSpec.groovy
@@ -1,0 +1,365 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package website.gradle.tasks
+
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+
+import spock.lang.Specification
+import spock.lang.TempDir
+
+class RecordCompanionReleaseTaskSpec extends Specification {
+
+    @TempDir
+    File tempDir
+
+    private static final String BASELINE_YAML = '''\
+companionArtifacts:
+  '7':
+    - artifactId: grails-spring-security
+      version: '7.0.2'
+      mirrorDirectory: spring-security
+      releaseNotesRepo: apache/grails-spring-security
+      displayName: Grails Spring Security Plugin
+    - artifactId: grails-redis
+      version: '5.0.1'
+      mirrorDirectory: redis
+      releaseNotesRepo: apache/grails-redis
+      displayName: Grails Redis Plugin
+
+coreReleases:
+  - version: 7.0.0
+'''
+
+    private RecordCompanionReleaseTask registerTask(File yaml) {
+        def project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+        RecordCompanionReleaseTask.register(project)
+        def task = project.tasks.getByName(RecordCompanionReleaseTask.NAME) as RecordCompanionReleaseTask
+        task.releasesYaml.set(yaml)
+        return task
+    }
+
+    private File writeReleases(String content) {
+        File f = new File(tempDir, 'releases.yml')
+        f.text = content
+        return f
+    }
+
+    void 'bumps version of an existing entry without touching surrounding lines'() {
+
+        given:
+            File yaml = writeReleases(BASELINE_YAML)
+            def task = registerTask(yaml)
+            task.grailsMajor.set('7')
+            task.artifactId.set('grails-redis')
+            task.artifactVersion.set('5.0.2')
+
+        when:
+            task.recordCompanionRelease()
+
+        then:
+            yaml.text == BASELINE_YAML.replace("version: '5.0.1'", "version: '5.0.2'")
+    }
+
+    void 'descriptor flags are silently ignored on the bump path'() {
+
+        given:
+            File yaml = writeReleases(BASELINE_YAML)
+            def task = registerTask(yaml)
+            task.grailsMajor.set('7')
+            task.artifactId.set('grails-redis')
+            task.artifactVersion.set('5.0.2')
+            task.mirrorDirectory.set('SHOULD-NOT-APPEAR')
+            task.releaseNotesRepo.set('SHOULD-NOT-APPEAR')
+            task.displayName.set('SHOULD-NOT-APPEAR')
+
+        when:
+            task.recordCompanionRelease()
+
+        then:
+            !yaml.text.contains('SHOULD-NOT-APPEAR')
+            yaml.text.contains("mirrorDirectory: redis")
+    }
+
+    void 'appends a new artifact entry to the end of an existing major block'() {
+
+        given:
+            File yaml = writeReleases(BASELINE_YAML)
+            def task = registerTask(yaml)
+            task.grailsMajor.set('7')
+            task.artifactId.set('grails-quartz')
+            task.artifactVersion.set('4.0.1')
+            task.mirrorDirectory.set('quartz')
+            task.releaseNotesRepo.set('apache/grails-quartz')
+            task.displayName.set('Grails Quartz Plugin')
+
+        when:
+            task.recordCompanionRelease()
+
+        then:
+            yaml.text == '''\
+companionArtifacts:
+  '7':
+    - artifactId: grails-spring-security
+      version: '7.0.2'
+      mirrorDirectory: spring-security
+      releaseNotesRepo: apache/grails-spring-security
+      displayName: Grails Spring Security Plugin
+    - artifactId: grails-redis
+      version: '5.0.1'
+      mirrorDirectory: redis
+      releaseNotesRepo: apache/grails-redis
+      displayName: Grails Redis Plugin
+    - artifactId: grails-quartz
+      version: '4.0.1'
+      mirrorDirectory: quartz
+      releaseNotesRepo: apache/grails-quartz
+      displayName: Grails Quartz Plugin
+
+coreReleases:
+  - version: 7.0.0
+'''
+    }
+
+    void 'bootstraps a brand-new major block at the end of companionArtifacts: preserving the blank-line separator'() {
+
+        given:
+            File yaml = writeReleases(BASELINE_YAML)
+            def task = registerTask(yaml)
+            task.grailsMajor.set('8')
+            task.artifactId.set('grails-publish')
+            task.artifactVersion.set('1.0.0-M1')
+            task.mirrorDirectory.set('grails-publish')
+            task.releaseNotesRepo.set('apache/grails-gradle-publish')
+            task.displayName.set('Grails Publish Gradle Plugin')
+
+        when:
+            task.recordCompanionRelease()
+
+        then:
+            yaml.text == '''\
+companionArtifacts:
+  '7':
+    - artifactId: grails-spring-security
+      version: '7.0.2'
+      mirrorDirectory: spring-security
+      releaseNotesRepo: apache/grails-spring-security
+      displayName: Grails Spring Security Plugin
+    - artifactId: grails-redis
+      version: '5.0.1'
+      mirrorDirectory: redis
+      releaseNotesRepo: apache/grails-redis
+      displayName: Grails Redis Plugin
+  '8':
+    - artifactId: grails-publish
+      version: '1.0.0-M1'
+      mirrorDirectory: grails-publish
+      releaseNotesRepo: apache/grails-gradle-publish
+      displayName: Grails Publish Gradle Plugin
+
+coreReleases:
+  - version: 7.0.0
+'''
+    }
+
+    void 'fails with a clear message when bootstrapping a new major without descriptor flags'() {
+
+        given:
+            File yaml = writeReleases(BASELINE_YAML)
+            def task = registerTask(yaml)
+            task.grailsMajor.set('8')
+            task.artifactId.set('grails-publish')
+            task.artifactVersion.set('1.0.0-M1')
+
+        when:
+            task.recordCompanionRelease()
+
+        then:
+            GradleException ex = thrown()
+            ex.message.contains("no '8': block exists yet")
+            ex.message.contains('-PmirrorDirectory')
+            ex.message.contains('-PreleaseNotesRepo')
+            ex.message.contains('-PdisplayName')
+    }
+
+    void 'fails with a clear message when adding a new artifact to an existing major without descriptor flags'() {
+
+        given:
+            File yaml = writeReleases(BASELINE_YAML)
+            def task = registerTask(yaml)
+            task.grailsMajor.set('7')
+            task.artifactId.set('grails-quartz')
+            task.artifactVersion.set('4.0.1')
+
+        when:
+            task.recordCompanionRelease()
+
+        then:
+            GradleException ex = thrown()
+            ex.message.contains('artifactId=grails-quartz is not yet listed')
+            ex.message.contains("under '7':")
+            ex.message.contains('-PmirrorDirectory')
+    }
+
+    void 'partial descriptor flags still trigger the missing-flags error listing only the missing ones'() {
+
+        given:
+            File yaml = writeReleases(BASELINE_YAML)
+            def task = registerTask(yaml)
+            task.grailsMajor.set('8')
+            task.artifactId.set('grails-publish')
+            task.artifactVersion.set('1.0.0-M1')
+            task.mirrorDirectory.set('grails-publish')
+
+        when:
+            task.recordCompanionRelease()
+
+        then:
+            GradleException ex = thrown()
+            !ex.message.contains('-PmirrorDirectory')
+            ex.message.contains('-PreleaseNotesRepo')
+            ex.message.contains('-PdisplayName')
+    }
+
+    void 'fails when releases.yml has no companionArtifacts section at all'() {
+
+        given:
+            File yaml = writeReleases('coreReleases:\n  - version: 7.0.0\n')
+            def task = registerTask(yaml)
+            task.grailsMajor.set('7')
+            task.artifactId.set('grails-redis')
+            task.artifactVersion.set('5.0.2')
+
+        when:
+            task.recordCompanionRelease()
+
+        then:
+            GradleException ex = thrown()
+            ex.message.contains('no companionArtifacts: section')
+    }
+
+    void 'fails when required core flags are missing'() {
+
+        given:
+            File yaml = writeReleases(BASELINE_YAML)
+            def task = registerTask(yaml)
+            task.grailsMajor.set('')
+            task.artifactId.set('grails-redis')
+            task.artifactVersion.set('5.0.2')
+
+        when:
+            task.recordCompanionRelease()
+
+        then:
+            GradleException ex = thrown()
+            ex.message.contains('-PgrailsMajor')
+            ex.message.contains('-PartifactId')
+            ex.message.contains('-PartifactVersion')
+    }
+
+    void 'preserves leading comments inside companionArtifacts: when bumping'() {
+
+        given:
+            String yamlWithComments = '''\
+companionArtifacts:
+  # leading comment that must survive
+  '7':
+    - artifactId: grails-redis
+      version: '5.0.1'
+      mirrorDirectory: redis
+      releaseNotesRepo: apache/grails-redis
+      displayName: Grails Redis Plugin
+
+coreReleases:
+  - version: 7.0.0
+'''
+            File yaml = writeReleases(yamlWithComments)
+            def task = registerTask(yaml)
+            task.grailsMajor.set('7')
+            task.artifactId.set('grails-redis')
+            task.artifactVersion.set('5.0.2')
+
+        when:
+            task.recordCompanionRelease()
+
+        then:
+            yaml.text.contains('# leading comment that must survive')
+            yaml.text.contains("version: '5.0.2'")
+            !yaml.text.contains("version: '5.0.1'")
+    }
+
+    void 'inserts a new entry between an existing major and the next major when both already exist'() {
+
+        given:
+            String yamlMultiMajor = '''\
+companionArtifacts:
+  '7':
+    - artifactId: grails-redis
+      version: '5.0.1'
+      mirrorDirectory: redis
+      releaseNotesRepo: apache/grails-redis
+      displayName: Grails Redis Plugin
+  '8':
+    - artifactId: grails-publish
+      version: '1.0.0-M1'
+      mirrorDirectory: grails-publish
+      releaseNotesRepo: apache/grails-gradle-publish
+      displayName: Grails Publish Gradle Plugin
+
+coreReleases:
+  - version: 7.0.0
+'''
+            File yaml = writeReleases(yamlMultiMajor)
+            def task = registerTask(yaml)
+            task.grailsMajor.set('7')
+            task.artifactId.set('grails-quartz')
+            task.artifactVersion.set('4.0.1')
+            task.mirrorDirectory.set('quartz')
+            task.releaseNotesRepo.set('apache/grails-quartz')
+            task.displayName.set('Grails Quartz Plugin')
+
+        when:
+            task.recordCompanionRelease()
+
+        then:
+            yaml.text == '''\
+companionArtifacts:
+  '7':
+    - artifactId: grails-redis
+      version: '5.0.1'
+      mirrorDirectory: redis
+      releaseNotesRepo: apache/grails-redis
+      displayName: Grails Redis Plugin
+    - artifactId: grails-quartz
+      version: '4.0.1'
+      mirrorDirectory: quartz
+      releaseNotesRepo: apache/grails-quartz
+      displayName: Grails Quartz Plugin
+  '8':
+    - artifactId: grails-publish
+      version: '1.0.0-M1'
+      mirrorDirectory: grails-publish
+      releaseNotesRepo: apache/grails-gradle-publish
+      displayName: Grails Publish Gradle Plugin
+
+coreReleases:
+  - version: 7.0.0
+'''
+    }
+}

--- a/conf/releases.yml
+++ b/conf/releases.yml
@@ -56,6 +56,12 @@ companionArtifacts:
       mirrorDirectory: grails-publish
       releaseNotesRepo: apache/grails-gradle-publish
       displayName: Grails Publish Gradle Plugin
+  '8':
+    - artifactId: grails-publish
+      version: '1.0.0-M1'
+      mirrorDirectory: grails-publish
+      releaseNotesRepo: apache/grails-gradle-publish
+      displayName: Grails Publish Gradle Plugin
 
 coreReleases:
   - version: '0.1'


### PR DESCRIPTION
## Summary

Two related changes that together unblock publishing a 1.0.0-M1 companion plugin (here: \`grails-publish\`) for a Grails major that hasn't shipped yet.

**Today**: \`recordCompanionRelease\` can only bump the \`version:\` line of an entry that already exists in \`conf/releases.yml\`'s \`companionArtifacts:\` section. Any first-time appearance of a \`(grailsMajor, artifactId)\` pair throws \`Could not find companionArtifact entry ... For a brand-new companion artifact, add the entry to conf/releases.yml manually first.\` and forces a manual edit because the task doesn't know \`mirrorDirectory\`, \`releaseNotesRepo\`, or \`displayName\`.

**After this PR**:

1. The task accepts three new optional flags - \`-PmirrorDirectory\`, \`-PreleaseNotesRepo\`, \`-PdisplayName\` - and uses them to perform first-time inserts. The decision is automatic based on what the file already contains:

   | State | Action | Descriptor flags |
   |---|---|---|
   | artifactId exists under \`'N':\` | bump \`version:\` in place | ignored (prevents URL drift mid-major) |
   | \`'N':\` exists, artifactId doesn't | append entry to end of \`'N':\` block | required |
   | no \`'N':\` block at all | append new major block to end of \`companionArtifacts:\`, preserving the blank-line separator before \`coreReleases:\` | required |

2. \`release-companion.yml\` workflow gains three matching \`workflow_dispatch\` inputs (\`mirror_directory\`, \`release_notes_repo\`, \`display_name\`) marked \`required: false\`. Operators only fill them on the first publish for each \`(major, artifactId)\` pair; subsequent bumps leave them blank.

3. \`conf/releases.yml\` gets the first user of the new path: a \`'8':\` block bootstrapped with \`grails-publish 1.0.0-M1\`. This is the pattern the question that motivated the PR was asking about ('how do I publish 1.0.0-M1 of a companion when Grails 8 doesn't exist yet?'). The renderer (DownloadPage, DocumentationPage, hero cards) only iterates over majors that have a corresponding stable core release in \`coreReleases:\`, so the entry is dormant in the rendered site until \`8.0.0-M1\` core ships - at which point the plugin's mirror URL and release-notes link are already populated, no further action needed on release day.

## Behaviour at a glance

| Operation | Today | After this PR |
|---|---|---|
| Bump existing entry (e.g. \`grails-redis 5.0.1 -> 5.0.2\`) | works via task | unchanged |
| Add new artifact to existing major (e.g. add \`grails-quartz\` to \`'7':\`) | manual PR | task supports it |
| Bootstrap new major (e.g. add \`'8':\` with first artifact) | manual PR | task supports it |
| Descriptor flags accidentally passed on bump | n/a | silently ignored |
| First-time insert without descriptor flags | n/a | clear error listing only the missing flags |

## Why ignore descriptor flags on the bump path

Changing \`mirrorDirectory\`, \`releaseNotesRepo\`, or \`displayName\` mid-major would break URLs that downstream pages and crawlers may have already indexed. Those changes intentionally still require a manual PR. The bump-path flag-ignoring is asserted by a dedicated test (\`descriptor flags are silently ignored on the bump path\`).

## Why \`grails-publish 1.0.0-M1\` and not other plugins

\`grails-publish\` is the Gradle plugin used to publish Grails artifacts to Maven Central - the toolchain has to be in place before the runtime can be cut, so it ships ahead of Grails 8 core. \`mirrorDirectory\`, \`releaseNotesRepo\`, and \`displayName\` mirror the existing \`'7':\` entry for the same artifactId since those are stable per-plugin identifiers, not per-major.

## Verification

- \`./gradlew :buildSrc:test\` runs 83 tests; 82 pass. The single failure (\`ValidateGuidesTaskSpec > shape mode rejects a non-40-char SHA\`) is pre-existing on master and unrelated to this PR - same one called out in #489's description.
- 11 new \`RecordCompanionReleaseTaskSpec\` scenarios cover all three operating paths (bump, new-artifact-existing-major, new-major), the two missing-flags error cases (no descriptor flags, partial descriptor flags), the missing-core-flags error, the no-companionArtifacts-section error, the comment-preservation regression case, and both cross-major insertion-point cases that surfaced during development (target major is the last block in the section vs target major is followed by a higher major).
- \`conf/releases.yml\` parses cleanly under SnakeYAML; \`SiteMap.companionArtifactsFor(file, 8)\` returns the bootstrapped \`grails-publish\` entry with all five fields populated. Verified manually via \`python3 -c \"import yaml; ...\"\`.

## Commit-by-commit walkthrough

1. **Extend recordCompanionRelease to bootstrap new majors and new artifacts** - task + workflow + tests; fully self-contained, no data changes.
2. **Add Grails 8 companionArtifacts block with grails-publish 1.0.0-M1** - data-only follow-up that exercises the manual schema before the workflow has a chance to run for an 8-targeted plugin.

Assisted-by: claude-code:claude-opus-4-7