### PR TITLE
Fix Key URL

### DIFF
--- a/buildSrc/src/main/groovy/website/model/documentation/DownloadPage.groovy
+++ b/buildSrc/src/main/groovy/website/model/documentation/DownloadPage.groovy
@@ -213,7 +213,7 @@ class DownloadPage {
                             ' the integrity of downloaded files by generating your own checksums and match ' +
                             'them against ours, and checking signatures using the '
                     )
-                    a(href: 'https://www.apache.org/dyn/closer.lua/grails/KEYS?action=download', 'KEYS')
+                    a(href: 'https://downloads.apache.org/grails/KEYS', 'KEYS')
                     mkp.yieldUnescaped(' file which contains the Grails OpenPGP release keys.')
                 }
 


### PR DESCRIPTION
Per [https://infra.apache.org/release-download-pages.html#download-page](https://infra.apache.org/release-download-pages.html#download-page):

All links to checksums, detached signatures and public keys must reference the Apache Distribution Directory ([downloads.apache.org](https://downloads.apache.org/)) and use https:// (SSL)