### PR TITLE
Add grails-github-actions-cicd v8 guide (rename of grails-on-github-actions)

### DIFF
--- a/conf/guides.yml
+++ b/conf/guides.yml
@@ -2238,6 +2238,61 @@ guides:
           helpWithGrails:
             title: Do you need help with Grails?  
 
+  - name: 'grails-github-actions-cicd'
+    title: 'GitHub Actions CI/CD with Grails 8'
+    subtitle: 'End-to-end CI/CD pipeline for a Grails 8 application: a multi-stage job graph (validation, unit, integration, functional) with PostgreSQL service containers and Geb + Testcontainers, plus a tag-triggered release workflow that builds the OCI image with bootBuildImage and pushes it to GHCR.'
+    authors:
+      - 'James Fredley'
+    category: 'Grails + DevOps'
+    publicationDate: '2026-05-03'
+    versions:
+      '8':
+        sourcePath: guides/grails-github-actions-cicd/v8
+        publicationDate: '2026-05-03'
+        tags:
+          - 'github-actions'
+          - 'ci-cd'
+          - 'gradle'
+          - 'testcontainers'
+          - 'geb'
+          - 'codecov'
+          - 'dependabot'
+          - 'ghcr'
+          - 'grails8'
+        sampleRef:
+          repo: 'grails-guides/grails-github-actions-cicd'
+          branch: 'grails8'
+        toc:
+          gettingStarted:
+            title: Getting Started
+            whatYouWillBuild: What You Will Build
+            requirements: What You Will Need
+            howto: How to Complete the Guide
+          createApp:
+            title: Creating the Application
+            download: Download a Grails 8 Snapshot Starter
+          workflowOverview:
+            title: The Multi-Stage Job Graph
+          ciYml:
+            title: The Canonical ci.yml
+          unitTests:
+            title: The Unit-Test Job
+          integrationTests:
+            title: The Integration-Test Job (Postgres Service Container)
+          functionalTests:
+            title: The Functional-Test Job (Geb + Testcontainers)
+          releaseYml:
+            title: The Release Workflow
+            ghcrPush: Pushing the OCI Image to GHCR
+          dependabot:
+            title: Dependabot for Gradle and Actions
+          branchProtection:
+            title: Required Status Checks
+          badge:
+            title: README Build Status Badge
+          helpWithGrails:
+            title: Do you need help with Grails?
+
   - name: 'grails-google-cloud'
     title: 'Deploy a Grails app to Google Cloud'
     subtitle: 'Learn how to deploy a Grails 3 application to Google App Engine Java Flexible Environment, integrate with Google Cloud Storage and Google Cloud SQL'
@@ -3105,7 +3160,7 @@ guides:
           - 'geb'
           - 'grails4'
         sampleRef:
-          repo: 'grails-guides/grails-on-github-actions'
+          repo: 'grails-guides/grails-github-actions-cicd'
           branch: 'master'
         toc:
           training:

--- a/guides/grails-github-actions-cicd/v8/guide/badge.adoc
+++ b/guides/grails-github-actions-cicd/v8/guide/badge.adoc
@@ -1,0 +1,10 @@
+A green badge in your README is the cheapest way to signal "this project's main branch is healthy". GitHub generates a per-workflow badge for free; copy the URL from *Actions -> CI -> ... -> Create status badge* and paste it as the first thing in the README:
+
+[source,markdown]
+----
+[![CI](https://github.com/your-org/your-repo/actions/workflows/ci.yml/badge.svg?branch=grails8)](https://github.com/your-org/your-repo/actions/workflows/ci.yml)
+----
+
+The `?branch=grails8` query string is non-optional. Without it, the badge reflects the most recent run on *any* branch, including stale feature-branch runs from months ago. With it, the badge tracks the branch you actually ship from.
+
+For projects with multiple workflows, add one badge per workflow. The badges line up nicely as a single bullet list at the top of the README.

--- a/guides/grails-github-actions-cicd/v8/guide/branchProtection.adoc
+++ b/guides/grails-github-actions-cicd/v8/guide/branchProtection.adoc
@@ -1,0 +1,9 @@
+The CI workflow is only useful if a PR cannot be merged when it is red. Configure that in *Settings -> Branches -> Branch protection rules -> Add rule*:
+
+* *Branch name pattern:* `grails8` (and `master`, if you keep one).
+* *Require a pull request before merging:* on, with at least one approval.
+* *Require status checks to pass before merging:* on, *Require branches to be up to date before merging:* on. In the search box add the four required jobs: `Wrapper validation + compile`, `Unit tests`, `Integration tests`, `Functional tests (Geb + Testcontainers)`. The `Coverage` job stays optional - a coverage drop is a hint, not a hard block.
+* *Require linear history:* on, if you prefer rebase merges over merge commits.
+* *Do not allow bypassing the above settings:* on, including for repository administrators (the link:https://owasp.org/Top10/A04_2021-Insecure_Design/[OWASP A04] guidance applies to your own repo too).
+
+Once branch protection is on, the *Merge* button on a PR turns grey until all four required checks return green. The PR author either fixes the failing job or asks the reviewer to override - which, with admin-bypass off, requires a second approval and an explicit force-merge.

--- a/guides/grails-github-actions-cicd/v8/guide/ciYml.adoc
+++ b/guides/grails-github-actions-cicd/v8/guide/ciYml.adoc
@@ -1,0 +1,15 @@
+Create the workflow file at `.github/workflows/ci.yml`:
+
+[source,yaml]
+..github/workflows/ci.yml
+----
+include::../snippets/.github/workflows/ci.yml[]
+----
+
+Three header blocks set the contract for every job:
+
+* `on:` triggers on every push and pull request to the `grails8` branch. We narrow to one branch on push (no point running CI for a feature branch's intermediate commits if a PR is going to do it anyway) but accept PRs from any branch.
+* `permissions: contents: read` follows the principle of least privilege: the CI workflow can only read the repo, not write to it. The release workflow asks for `contents: write` and `packages: write` separately.
+* `concurrency:` cancels older runs when a new push lands on the same ref. This stops a long functional-test run from blocking a fix-up commit; the older run is killed and the newer one starts immediately.
+
+Each job uses `runs-on: ubuntu-latest`, `actions/checkout@v4`, `actions/setup-java@v4` (with `distribution: liberica` and `java-version: 21`), and `gradle/actions/setup-gradle@v4`. The setup-gradle action manages the build cache and dependency cache; setting `cache-read-only: true` on consumer jobs (anything except the writer on `grails8`) means PR builds get a free read-through cache without polluting the cache with PR-specific artefacts.

--- a/guides/grails-github-actions-cicd/v8/guide/createApp.adoc
+++ b/guides/grails-github-actions-cicd/v8/guide/createApp.adoc
@@ -1,0 +1,1 @@
+Generate a fresh Apache Grails 8 web application from link:https://prev-snapshot.grails.org[prev-snapshot.grails.org] with the three features the rest of the guide expects: `postgres`, `testcontainers`, and `geb-with-webdriver-binaries` (so functional tests can drive a headless browser).

--- a/guides/grails-github-actions-cicd/v8/guide/dependabot.adoc
+++ b/guides/grails-github-actions-cicd/v8/guide/dependabot.adoc
@@ -1,0 +1,17 @@
+A `.github/dependabot.yml` keeps dependency drift in check without you remembering to look:
+
+[source,yaml]
+..github/dependabot.yml
+----
+include::../snippets/.github/dependabot.yml[]
+----
+
+Two ecosystems get watched: `gradle` (your runtime + test dependencies declared in `build.gradle`) and `github-actions` (the actions referenced in the workflow YAML files themselves). Both run weekly on Monday morning to batch up the noise, and `open-pull-requests-limit: 5` caps the in-flight PR count so a quiet week does not become a 30-PR avalanche.
+
+The `groups:` block under `gradle` collapses what would otherwise be a flood of single-dependency bumps into three semantic PRs:
+
+* All `org.apache.grails*` updates land as one PR (so a Grails minor bump arrives intact, not as fifteen separate dependency bumps).
+* All `org.springframework*` updates land as one PR (Spring releases its modules together).
+* All testing-framework updates (Spock, Testcontainers, Mockito) land as one PR.
+
+Anything that does not match a group falls back to one PR per dependency. The result is typically 5 to 8 PRs per week instead of 30+.

--- a/guides/grails-github-actions-cicd/v8/guide/download.adoc
+++ b/guides/grails-github-actions-cicd/v8/guide/download.adoc
@@ -1,0 +1,13 @@
+[source,bash]
+----
+curl -L -o cicd-app.zip \
+  "https://prev-snapshot.grails.org/create/web/example.cicd?lang=GROOVY&build=GRADLE&test=SPOCK&javaVersion=JDK_21&features=postgres,testcontainers,geb-with-webdriver-binaries"
+unzip cicd-app.zip
+cd cicd
+----
+
+The forge unpacks into a `cicd/` directory containing a vanilla Grails 8 web layout with three feature-driven additions:
+
+* `runtimeOnly "org.postgresql:postgresql"` and a Postgres datasource template
+* `testImplementation "org.testcontainers:postgresql"` (and `org.testcontainers:spock` + `:testcontainers`)
+* `integrationTestImplementation testFixtures("org.apache.grails:grails-geb")` and `com.energizedwork.gebish:webdriver-binaries-gradle-plugin` for downloading Chrome/Firefox driver binaries automatically

--- a/guides/grails-github-actions-cicd/v8/guide/functionalTests.adoc
+++ b/guides/grails-github-actions-cicd/v8/guide/functionalTests.adoc
@@ -1,0 +1,30 @@
+The `functional-test` job boots the application against a Testcontainers-managed Postgres and drives it with Geb 8 specs. Because it does not declare a `services.postgres` block, the runner is a plain Ubuntu VM; Testcontainers spins up Postgres on demand from the test JVM via the local Docker socket (which GitHub-hosted runners expose by default).
+
+[source,yaml]
+----
+  functional-test:
+    name: Functional tests (Geb + Testcontainers)
+    needs: integration-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: liberica
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: true
+      - run: ./gradlew --no-daemon functionalTest
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: geb-reports
+          path: |
+            build/reports/tests/functionalTest/
+            build/geb-reports/
+----
+
+`if: always()` on the geb-reports upload is intentional: even on a green run you may want the screenshots from `build/geb-reports/` to confirm the page rendered as expected. On a red run, those screenshots are how you debug "works on my machine" failures - the runner's screenshot of the failed page is usually enough to spot the missing element.
+
+The `geb-with-webdriver-binaries` feature you selected at the forge step downloads matching Chrome/Firefox driver binaries on the fly via `webdriver-binaries-gradle-plugin`, so no `apt-get install` of the browsers themselves is needed - the plugin handles both the browser and the driver.

--- a/guides/grails-github-actions-cicd/v8/guide/gettingStarted.adoc
+++ b/guides/grails-github-actions-cicd/v8/guide/gettingStarted.adoc
@@ -1,0 +1,9 @@
+In this guide you will set up a complete GitHub Actions CI/CD pipeline for an Apache Grails 8 application. The pipeline replaces the patterns in the seven-year-old link:https://grails.apache.org/guides/grails-on-github-actions/4/guide/index.html[Grails on GitHub Actions] guide, all of whose actions are now deprecated.
+
+You will end up with three files in `.github/`:
+
+* `workflows/ci.yml` - a four-stage job graph (validation -> unit tests -> integration tests -> functional tests) that runs on every push and pull request to the `grails8` branch.
+* `workflows/release.yml` - tag-triggered release pipeline that builds the OCI image with `bootBuildImage` (from the link:../grails-docker-bootbuildimage/8/guide/index.html[Docker bootBuildImage] guide), pushes to GitHub Container Registry, and creates a GitHub Release with the bootJar attached.
+* `dependabot.yml` - weekly Gradle and GitHub Actions updates with grouped Grails / Spring / testing PRs.
+
+This guide targets Apache Grails 8 / Spring Boot 4 / JDK 21.

--- a/guides/grails-github-actions-cicd/v8/guide/ghcrPush.adoc
+++ b/guides/grails-github-actions-cicd/v8/guide/ghcrPush.adoc
@@ -1,0 +1,11 @@
+The `Build and publish OCI image` step in `release.yml` calls the same `bootBuildImage` task introduced in the link:../grails-docker-bootbuildimage/8/guide/index.html[Docker bootBuildImage] guide, with two CI-specific flags:
+
+* `--imageName=ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}` overrides the build.gradle default at runtime, ensuring every release lands at the canonical GHCR path.
+* `--publishImage` plus the registry credentials publish the image directly to the registry without a separate `docker push` step.
+
+The credentials come from `docker/login-action@v3`, which uses `${{ secrets.GITHUB_TOKEN }}` - a repository-scoped token that GitHub auto-provisions for every workflow run. No personal access token to mint, no secret to rotate, no audit trail to maintain. The token is automatically scoped to `packages: write` because we declared it at workflow level.
+
+[TIP]
+====
+The first time the release workflow pushes to `ghcr.io/your-org/your-repo`, the package is created as private. Make it public via the GitHub UI (Package settings -> Change visibility -> Public) so anonymous pulls work. After that, every subsequent release inherits the visibility.
+====

--- a/guides/grails-github-actions-cicd/v8/guide/helpWithGrails.adoc
+++ b/guides/grails-github-actions-cicd/v8/guide/helpWithGrails.adoc
@@ -1,0 +1,1 @@
+include::{commondir}/common-helpWithGrails.adoc[]

--- a/guides/grails-github-actions-cicd/v8/guide/howto.adoc
+++ b/guides/grails-github-actions-cicd/v8/guide/howto.adoc
@@ -1,0 +1,13 @@
+You can either type the YAML in this guide as you read or skip ahead and clone the finished sample app:
+
+[source,bash]
+----
+git clone -b grails8 https://github.com/grails-guides/grails-github-actions-cicd.git
+cd grails-github-actions-cicd/complete
+./gradlew test
+----
+
+The repository contains two top-level directories:
+
+* `initial/` - the starting Grails 8 snapshot project, generated from `https://prev-snapshot.grails.org` with the `postgres`, `testcontainers`, and `geb-with-webdriver-binaries` features.
+* `complete/` - the same project with the three workflow YAML files added under `.github/`.

--- a/guides/grails-github-actions-cicd/v8/guide/integrationTests.adoc
+++ b/guides/grails-github-actions-cicd/v8/guide/integrationTests.adoc
@@ -1,0 +1,25 @@
+The `integration-test` job needs a database. GitHub Actions service containers are the cheapest path: declare a `services.postgres` block, GitHub starts the container before the steps run, and the integration test connects to it via `localhost:5432`:
+
+[source,yaml]
+----
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: testDb
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+----
+
+The three datasource environment variables on the `./gradlew integrationTest` step (`SPRING_DATASOURCE_URL`, `_USERNAME`, `_PASSWORD`) match the `${SPRING_DATASOURCE_URL:fallback}` placeholders in `application.yml` from the link:../grails-docker-bootbuildimage/8/guide/envProfiles.html[Docker bootBuildImage envProfiles] chapter, so the same wiring serves both CI and Compose.
+
+[NOTE]
+====
+For the *functional* tests in the next chapter we switch from a service container to Testcontainers' Postgres. The trade-off: service containers are faster to spin up (the postgres image is already cached on the runner) but force every test in the suite to share the same database. Testcontainers gives each spec its own fresh container at the cost of an extra container start per spec class. For functional tests where database state isolation matters more than wall-clock speed, Testcontainers wins.
+====

--- a/guides/grails-github-actions-cicd/v8/guide/releaseYml.adoc
+++ b/guides/grails-github-actions-cicd/v8/guide/releaseYml.adoc
@@ -1,0 +1,13 @@
+A separate workflow at `.github/workflows/release.yml` triggers on tag pushes and produces (a) an OCI image on GitHub Container Registry, (b) a GitHub Release with the bootJar attached:
+
+[source,yaml]
+..github/workflows/release.yml
+----
+include::../snippets/.github/workflows/release.yml[]
+----
+
+Three pieces are doing the work:
+
+* `on.push.tags: ['v*.*.*']` triggers the workflow when a tag matching `v1.2.3` is pushed. The matching `workflow_dispatch` block lets you run the same pipeline manually from the Actions tab against an arbitrary branch when you need an out-of-band release.
+* `permissions: contents: write` (for the GitHub Release) + `packages: write` (for the GHCR push) is the strict minimum the workflow needs. The two are declared at workflow level rather than job level only because every job in this workflow needs both.
+* The `Resolve release version` step extracts the version from the tag (`v1.2.3` -> `1.2.3`) when triggered by tag push, or uses the manual input on `workflow_dispatch`. Every later step references `${{ steps.version.outputs.version }}` so the version flows through to `gradlew`, the image tag, and the release name.

--- a/guides/grails-github-actions-cicd/v8/guide/requirements.adoc
+++ b/guides/grails-github-actions-cicd/v8/guide/requirements.adoc
@@ -1,0 +1,5 @@
+To complete this guide you will need:
+
+* JDK 21
+* A GitHub account that owns or has push access to the repository hosting the application
+* About 30 minutes

--- a/guides/grails-github-actions-cicd/v8/guide/unitTests.adoc
+++ b/guides/grails-github-actions-cicd/v8/guide/unitTests.adoc
@@ -1,0 +1,29 @@
+The `unit-test` job runs just `./gradlew test`:
+
+[source,yaml]
+----
+  unit-test:
+    name: Unit tests
+    needs: validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: liberica
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: true
+      - run: ./gradlew --no-daemon test
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: unit-test-reports
+          path: build/reports/tests/test/
+----
+
+Two patterns worth pointing at:
+
+* `if: failure()` on the artefact upload uploads test reports only when the job fails. On success there is no point in carrying around `index.html` files; on failure they are the first thing you click on.
+* `--no-daemon` ensures the JVM starts cold and reports honest first-run times. The Gradle dependency cache is still warm; the daemon caching disagreement was about JVM warm-up, not classpath resolution.

--- a/guides/grails-github-actions-cicd/v8/guide/whatYouWillBuild.adoc
+++ b/guides/grails-github-actions-cicd/v8/guide/whatYouWillBuild.adoc
@@ -1,0 +1,11 @@
+By the end of the guide your project will have:
+
+* `actions/setup-java@v4` pinning the JDK to Liberica 21 (the same distribution Paketo's bootBuildImage uses, so build-time and runtime bytecode levels agree).
+* `gradle/actions/wrapper-validation@v4` running before any other Gradle invocation, so a tampered `gradle-wrapper.jar` cannot exfiltrate build-time secrets.
+* `gradle/actions/setup-gradle@v4` configuring the Gradle build cache + dependency cache so the `unitTest`, `integrationTest`, and `functionalTest` jobs each cold-start in seconds, not minutes.
+* A multi-stage job graph - `validation` -> `unit-test` + `integration-test` -> `functional-test` -> `coverage` - so failures are isolated to the layer that broke and `functional-test` does not run if the unit suite is already broken.
+* PostgreSQL service containers for the `integration-test` job and Testcontainers-driven Postgres for the `functional-test` job (Geb specs against the real booted app).
+* A separate `release.yml` triggered on `v*.*.*` tags that builds the OCI image with `bootBuildImage`, pushes to GHCR, and attaches the `bootJar` to a GitHub Release.
+* A `codecov/codecov-action@v5` upload from the `coverage` job.
+* A `dependabot.yml` covering Gradle and GitHub Actions, with grouped PRs so a Grails minor bump arrives as one PR instead of fifteen.
+* A README badge that turns green when the latest build on `grails8` passes.

--- a/guides/grails-github-actions-cicd/v8/guide/workflowOverview.adoc
+++ b/guides/grails-github-actions-cicd/v8/guide/workflowOverview.adoc
@@ -1,0 +1,17 @@
+The CI workflow is intentionally split into five jobs that form a directed acyclic graph:
+
+```
+                  validation
+                  /         \
+            unit-test    integration-test
+                  \         /
+                   coverage         functional-test
+```
+
+`validation` runs first and is the gate for everything else. It validates the Gradle wrapper, sets up the toolchain, and compiles `classes` + `testClasses` so that any compile-time error fails fast in under a minute.
+
+`unit-test` and `integration-test` run in parallel, both depending on `validation`. They are the bulk of the runtime - 80% of the wall-clock budget. Splitting them lets you see in `Actions` -> `Summary` whether the regression is in business logic (unit tests) or in database/transaction wiring (integration tests).
+
+`functional-test` depends on `integration-test` (a green integration suite is a precondition for booting the app and driving it with Geb). It uses Testcontainers for Postgres rather than a service container so it can be the same Spock specs you run locally.
+
+`coverage` depends on `unit-test` and `integration-test` and uploads the merged JaCoCo report to Codecov. It does not block PR review on coverage drops; that is a soft gate that lives in Codecov's PR comment.

--- a/guides/grails-github-actions-cicd/v8/snippets/.github/dependabot.yml
+++ b/guides/grails-github-actions-cicd/v8/snippets/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+
+  # Gradle dependencies (build.gradle, settings.gradle, buildSrc)
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+      timezone: 'Etc/UTC'
+    labels: ['dependencies', 'gradle']
+    open-pull-requests-limit: 5
+    groups:
+      grails:
+        patterns: ['org.apache.grails*']
+      spring:
+        patterns: ['org.springframework*']
+      testing:
+        patterns: ['org.spockframework*', 'org.testcontainers*', 'org.mockito*']
+
+  # GitHub Actions versions in the workflow files themselves
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+      timezone: 'Etc/UTC'
+    labels: ['dependencies', 'github-actions']
+    open-pull-requests-limit: 5

--- a/guides/grails-github-actions-cicd/v8/snippets/.github/workflows/ci.yml
+++ b/guides/grails-github-actions-cicd/v8/snippets/.github/workflows/ci.yml
@@ -1,0 +1,131 @@
+name: CI
+
+on:
+  push:
+    branches: [grails8]
+  pull_request:
+    branches: [grails8]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  validation:
+    name: Wrapper validation + compile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: liberica
+          java-version: 21
+      - uses: gradle/actions/wrapper-validation@v4
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/grails8' }}
+      - run: ./gradlew --no-daemon classes testClasses
+
+  unit-test:
+    name: Unit tests
+    needs: validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: liberica
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: true
+      - run: ./gradlew --no-daemon test
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: unit-test-reports
+          path: build/reports/tests/test/
+
+  integration-test:
+    name: Integration tests
+    needs: validation
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: testDb
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: liberica
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: true
+      - run: ./gradlew --no-daemon integrationTest
+        env:
+          SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5432/testDb
+          SPRING_DATASOURCE_USERNAME: postgres
+          SPRING_DATASOURCE_PASSWORD: postgres
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: integration-test-reports
+          path: build/reports/tests/integrationTest/
+
+  functional-test:
+    name: Functional tests (Geb + Testcontainers)
+    needs: integration-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: liberica
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: true
+      - run: ./gradlew --no-daemon functionalTest
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: geb-reports
+          path: |
+            build/reports/tests/functionalTest/
+            build/geb-reports/
+
+  coverage:
+    name: Upload coverage
+    needs: [unit-test, integration-test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: liberica
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: true
+      - run: ./gradlew --no-daemon jacocoTestReport
+      - uses: codecov/codecov-action@v5
+        with:
+          files: build/reports/jacoco/test/jacocoTestReport.xml
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/guides/grails-github-actions-cicd/v8/snippets/.github/workflows/release.yml
+++ b/guides/grails-github-actions-cicd/v8/snippets/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*.*.*']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. 1.0.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+
+  build-and-publish:
+    name: Build OCI image and create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v4
+
+      - id: version
+        name: Resolve release version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: liberica
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build bootJar
+        run: ./gradlew --no-daemon -Pversion=${{ steps.version.outputs.version }} bootJar
+
+      - name: Build and publish OCI image
+        run: |
+          ./gradlew --no-daemon -Pversion=${{ steps.version.outputs.version }} \
+            bootBuildImage \
+            --imageName=ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }} \
+            --publishImage \
+          --publicationRegistry.username=${{ github.actor }} \
+          --publicationRegistry.password=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          name: ${{ steps.version.outputs.version }}
+          generate_release_notes: true
+          files: build/libs/*.jar


### PR DESCRIPTION
## Summary

Adds the **GitHub Actions CI/CD with Grails 8** guide as the fourth Grails 8 sample-app-flavour guide, following PR #479 (fields), #493 (Tailwind), and #494 (Docker bootBuildImage).

Modern replacement for the seven-year-old [grails-on-github-actions v4 guide](https://grails.apache.org/guides/grails-on-github-actions/4/guide/index.html), all of whose actions are now deprecated. Establishes the canonical multi-stage workflow with `actions/setup-java@v4`, `gradle/actions/wrapper-validation@v4`, and `gradle/actions/setup-gradle@v4`.

## Companion conf/guides.yml change (rename of upstream repo)

The upstream repo `grails-guides/grails-on-github-actions` was renamed to `grails-guides/grails-github-actions-cicd`. GitHub auto-redirects keep historical clones working; this PR repoints the v4 entry's `sampleRef.repo` (line 3108) at the new canonical name. The `master` branch is preserved on the renamed repo so the v4 guide's sample-app reference continues to resolve.

## What's in the PR

- `conf/guides.yml` - new `grails-github-actions-cicd` registry entry plus the v4-entry repo-name update.
- `guides/grails-github-actions-cicd/v8/guide/*.adoc` - 17 chapters covering the CI workflow, release workflow, Dependabot, branch protection, and the README badge.
- `guides/grails-github-actions-cicd/v8/snippets/.github/` - vendored `workflows/ci.yml`, `workflows/release.yml`, and `dependabot.yml`.

## Workflow shape

`ci.yml` job graph (each arrow is a `needs:` edge):

`
                  validation
                  /         \
            unit-test    integration-test (Postgres service container)
                  \         /
                   coverage         functional-test (Geb + Testcontainers)
`

`release.yml` triggers on `v*.*.*` tag pushes, runs `./gradlew bootBuildImage` against the Docker bootBuildImage guide's Spring Boot 4 task, pushes to GHCR via `docker/login-action@v3` + `--publishImage`, and creates a GitHub Release with the bootJar attached using `softprops/action-gh-release@v2`.

`dependabot.yml` covers `gradle` and `github-actions` ecosystems with grouped PRs (Grails / Spring / testing) so a Grails minor bump arrives as one PR, not fifteen.

## Upstream sample app

[`grails-guides/grails-github-actions-cicd`](https://github.com/grails-guides/grails-github-actions-cicd) on the `grails8` branch contains the standard `initial/` + `complete/` layout. `initial/` is the vanilla forge output with the `postgres`, `testcontainers`, and `geb-with-webdriver-binaries` features. `complete/` adds the three `.github/` files.

## Verification

- `./gradlew validateGuides -PvalidationMode=both` returns **86 guides, 0 errors**.
- `./gradlew renderGuide_grails_github_actions_cicd_8 --rerun-tasks --no-configuration-cache` renders all 17 chapter HTML pages, no Unresolved directive errors.

## Cross-reference

The `releaseYml` and `ghcrPush` chapters reference [PR #494](https://github.com/apache/grails-static-website/pull/494) (`grails-docker-bootbuildimage`); merging that one before this one makes the cross-link target resolve. The two PRs are otherwise independent.

## Notes for reviewers

- This is the third Grails 8 PR that intentionally renames an existing `grails-guides/*` repo to a sharper name (after PR #494 for Docker). Same pattern: GitHub auto-redirects, `conf/guides.yml` repointed to the new name, original branches preserved.
- The functional-test job uses Testcontainers (per-spec Postgres container) rather than a service container so the same Spock specs run identically locally and in CI.