### PR TITLE
Add grails-htmx v8 guide

### DIFF
--- a/conf/guides.yml
+++ b/conf/guides.yml
@@ -2429,6 +2429,57 @@ guides:
           helpWithGrails:
               title: Help with Grails
 
+  - name: 'grails-htmx'
+    title: 'HTMX with Grails 8'
+    subtitle: 'Build a small task tracker with server-rendered Grails 8 GSP and HTMX-driven inline editing, live search, optimistic delete, and toggle - no SPA, no JSON.'
+    authors:
+      - 'James Fredley'
+    category: 'Web Layer'
+    publicationDate: '2026-05-03'
+    versions:
+      '8':
+        sourcePath: guides/grails-htmx/v8
+        publicationDate: '2026-05-03'
+        tags:
+          - 'htmx'
+          - 'gsp'
+          - 'partials'
+          - 'no-spa'
+          - 'grails8'
+        sampleRef:
+          repo: 'grails-guides/grails-htmx'
+          branch: 'grails8'
+        toc:
+          gettingStarted:
+            title: Getting Started
+            whatYouWillBuild: What You Will Build
+            requirements: What You Will Need
+            howto: How to Complete the Guide
+          createApp:
+            title: Creating the Application
+          taskDomain:
+            title: The Task Domain Class
+          layoutWithHtmx:
+            title: Adding HTMX to the Layout
+          urlMappings:
+            title: URL Mappings
+          controller:
+            title: The TaskController
+          indexPage:
+            title: The Initial Page
+          rowPartial:
+            title: The Row Partial
+          inlineEdit:
+            title: Inline Edit With Validation
+          liveSearch:
+            title: Live Search
+          csrf:
+            title: CSRF With HTMX
+          spaComparison:
+            title: HTMX vs an SPA
+          helpWithGrails:
+            title: Do you need help with Grails?
+
   - name: 'grails-javamelody'
     title: 'JavaMelody monitoring with Grails 3'
     subtitle: 'Learn how to setup and monitor your application using JavaMelody'

--- a/guides/grails-htmx/v8/guide/controller.adoc
+++ b/guides/grails-htmx/v8/guide/controller.adoc
@@ -1,0 +1,14 @@
+`TaskController` has seven actions, but only `index` returns a full page. Every other action returns a single GSP partial via `render template: '...'`:
+
+[source,groovy]
+.grails-app/controllers/example/TaskController.groovy
+----
+include::../snippets/grails-app/controllers/example/TaskController.groovy[]
+----
+
+A few patterns to point at:
+
+* `static allowedMethods = [...]` rejects mismatched HTTP verbs at the framework level. Sending `GET /tasks` to `create` returns 405, not silently calling the action.
+* The `@Transactional(readOnly = true)` class annotation flips read-only mode on for the whole controller; individual mutating actions override with their own `@Transactional`.
+* On a validation failure (`!t.save()`), the controller returns a 422 with the error fragment. HTMX swaps that fragment into the page, the user sees the error inline, and the form remains in the DOM ready for another attempt.
+* `delete` returns an empty body. Combined with `hx-swap="outerHTML"` on the delete button, this removes the row from the DOM.

--- a/guides/grails-htmx/v8/guide/createApp.adoc
+++ b/guides/grails-htmx/v8/guide/createApp.adoc
@@ -1,0 +1,11 @@
+Generate a fresh Apache Grails 8 web application from link:https://prev-snapshot.grails.org[prev-snapshot.grails.org]:
+
+[source,bash]
+----
+curl -L -o htmx-app.zip \
+  "https://prev-snapshot.grails.org/create/web/example.htmxtasks?lang=GROOVY&build=GRADLE&test=SPOCK&javaVersion=JDK_21"
+unzip htmx-app.zip
+cd htmxtasks
+----
+
+The default `web` starter ships GSP, the asset pipeline, and Bootstrap 5 webjars - all of which we will reuse.

--- a/guides/grails-htmx/v8/guide/csrf.adoc
+++ b/guides/grails-htmx/v8/guide/csrf.adoc
@@ -1,0 +1,23 @@
+Grails' `<g:form>` tag automatically inserts a `SYNCHRONIZER_TOKEN` parameter when the controller declares `static withForm = ...`. HTMX requests do not go through `<g:form>`, so the token has to be wired in differently.
+
+The HTMX configuration block in `main.gsp` reads the token from a `<meta>` tag and forwards it as a custom header on every request:
+
+[source,html]
+----
+<meta name="csrf-token" content="${useToken().token}"/>
+<script>
+    document.body.addEventListener('htmx:configRequest', function(evt) {
+        var meta = document.querySelector('meta[name="csrf-token"]');
+        if (meta) {
+            evt.detail.headers['X-Grails-Csrf-Token'] = meta.content;
+        }
+    });
+</script>
+----
+
+A matching `before` interceptor checks the header on every state-changing request and rejects mismatches with a 403. For a sample app the token check is overkill; for a real back-office the few lines of plumbing buy you the same protection `<g:form>` provides for traditional forms.
+
+[NOTE]
+====
+The `Origin` and `Referer` headers also defeat CSRF for fetch-based clients. Modern browsers send them automatically and a same-origin check is one line of interceptor code. Belt-and-braces shops do both; pick the discipline that matches your threat model.
+====

--- a/guides/grails-htmx/v8/guide/gettingStarted.adoc
+++ b/guides/grails-htmx/v8/guide/gettingStarted.adoc
@@ -1,0 +1,5 @@
+In this guide you will build a small task tracker on Apache Grails 8 with link:https://htmx.org[HTMX] driving the UI - server-rendered initial page, then HTMX-driven inline editing, live search, optimistic delete with confirm, and toggle, all without committing to a full SPA.
+
+The pattern is a natural fit for Grails: GSP partials become HTMX response fragments. Your controllers return small chunks of HTML instead of JSON; HTMX swaps them into the right slot. Forms post to controllers via `hx-post` and validation errors come back as the same partial with the errors rendered inline.
+
+This guide targets Apache Grails 8 / HTMX 2.x.

--- a/guides/grails-htmx/v8/guide/helpWithGrails.adoc
+++ b/guides/grails-htmx/v8/guide/helpWithGrails.adoc
@@ -1,0 +1,1 @@
+include::{commondir}/common-helpWithGrails.adoc[]

--- a/guides/grails-htmx/v8/guide/howto.adoc
+++ b/guides/grails-htmx/v8/guide/howto.adoc
@@ -1,0 +1,11 @@
+You can either type the code in this guide as you read or skip ahead and clone the finished sample:
+
+[source,bash]
+----
+git clone -b grails8 https://github.com/grails-guides/grails-htmx.git
+cd grails-htmx/complete
+./gradlew bootRun
+# open http://localhost:8080/tasks
+----
+
+`initial/` is a vanilla Grails 8 starter. `complete/` adds the Task domain, the controller, the GSP partials, and the HTMX script tag.

--- a/guides/grails-htmx/v8/guide/indexPage.adoc
+++ b/guides/grails-htmx/v8/guide/indexPage.adoc
@@ -1,0 +1,15 @@
+The full page is rendered once on `GET /tasks`:
+
+[source,html]
+.grails-app/views/task/index.gsp
+----
+include::../snippets/grails-app/views/task/index.gsp[]
+----
+
+Three HTMX patterns are in play:
+
+* The *add-task form* posts to `/tasks` (`hx-post`) and prepends the response to `#taskList` (`hx-target="#taskList"`, `hx-swap="afterbegin"`). The `hx-on::after-request="this.reset()"` clears the input after a successful submission.
+* The *live-search input* fires a `GET /tasks/search?q=...` whenever the user pauses typing for 300 ms (`hx-trigger="keyup changed delay:300ms"`). The response replaces the contents of `#taskList`.
+* The *initial render* uses `<g:render template="taskRows" .../>` to populate the list server-side. HTMX takes over from there.
+
+This is the canonical HTMX recipe: render once on the server, then let small fragments shuttle in and out of well-defined slots in the DOM.

--- a/guides/grails-htmx/v8/guide/inlineEdit.adoc
+++ b/guides/grails-htmx/v8/guide/inlineEdit.adoc
@@ -1,0 +1,13 @@
+Clicking a task title swaps the row out for an edit form. Saving swaps it back. The state never leaves the server.
+
+[source,html]
+.grails-app/views/task/_taskEdit.gsp
+----
+include::../snippets/grails-app/views/task/_taskEdit.gsp[]
+----
+
+Three patterns to highlight:
+
+* The form's `hx-patch` posts to `/tasks/{id}` with the PATCH method. The response is either the read-only `_task.gsp` (success) or the same edit form with the validation errors rendered (failure).
+* `<g:eachError bean="${task}">` renders the field errors inline. Because Grails populates `task.errors` when `save()` fails, the same partial template handles both success and failure. The HTTP status (200 vs 422) is what tells HTMX which one - both swap into the same slot.
+* The Cancel button does a `hx-get` for `/tasks/{id}` (which returns the read-only row partial) so cancelling does not require any new wiring.

--- a/guides/grails-htmx/v8/guide/layoutWithHtmx.adoc
+++ b/guides/grails-htmx/v8/guide/layoutWithHtmx.adoc
@@ -1,0 +1,11 @@
+HTMX is a single ~14 KB script. The starter's layout already loads stylesheets and the Grails javascript bundle; add the HTMX script tag in `<head>`:
+
+[source,html]
+.grails-app/views/layouts/main.gsp
+----
+include::../snippets/grails-app/views/layouts/main.gsp[]
+----
+
+The `integrity=` attribute uses a Subresource Integrity hash that the browser verifies before executing - protecting you against a CDN compromise. Keep it in sync with the version in the `src` URL.
+
+For production, vendor the file under `grails-app/assets/javascripts/htmx.min.js` and load via `<asset:javascript src="htmx.min.js"/>` so deployments do not depend on the CDN.

--- a/guides/grails-htmx/v8/guide/liveSearch.adoc
+++ b/guides/grails-htmx/v8/guide/liveSearch.adoc
@@ -1,0 +1,31 @@
+Live search is one input element with three HTMX attributes:
+
+[source,html]
+----
+<input type="text"
+       name="q"
+       placeholder="Search tasks..."
+       hx-get="${createLink(controller: 'task', action: 'search')}"
+       hx-trigger="keyup changed delay:300ms"
+       hx-target="#taskList"
+       hx-swap="innerHTML"/>
+----
+
+The `hx-trigger="keyup changed delay:300ms"` modifier composition is the entire UX:
+
+* `keyup` - fire on every key release.
+* `changed` - skip if the input value did not actually change since the last request (so arrow keys, modifiers, and Ctrl+A do not trigger a network round-trip).
+* `delay:300ms` - wait 300 ms after the last keyup before sending. New keypresses cancel the pending request and reset the timer.
+
+The server-side action is one line of GORM:
+
+[source,groovy]
+----
+def search() {
+    String q = (params.q ?: '') as String
+    List<Task> rows = q ? Task.findAllByTitleIlike("%${q}%") : Task.list()
+    render template: 'taskRows', model: [tasks: rows]
+}
+----
+
+`findAllByTitleIlike` is GORM's case-insensitive LIKE; it forwards to a parameterised SQL query, so no SQL injection concerns. The `_taskRows.gsp` partial handles both the populated and empty states.

--- a/guides/grails-htmx/v8/guide/requirements.adoc
+++ b/guides/grails-htmx/v8/guide/requirements.adoc
@@ -1,0 +1,4 @@
+To complete this guide you will need:
+
+* JDK 21
+* About 30 minutes

--- a/guides/grails-htmx/v8/guide/rowPartial.adoc
+++ b/guides/grails-htmx/v8/guide/rowPartial.adoc
@@ -1,0 +1,28 @@
+Every row is a `_task.gsp` partial. The same partial is used by:
+
+* The initial server render (via `_taskRows.gsp` which iterates `_task.gsp`).
+* The "create" response after a successful POST.
+* The "toggle done" response.
+* The "save edit" response.
+
+[source,html]
+.grails-app/views/task/_task.gsp
+----
+include::../snippets/grails-app/views/task/_task.gsp[]
+----
+
+Three HTMX-specific things in this partial:
+
+* The toggle-done button uses `hx-target="closest li"` `hx-swap="outerHTML"`. After the POST, the new HTML replaces *this entire row* in place. The `closest` modifier walks up the DOM until it finds an `<li>`.
+* Clicking the title fires a `hx-get` for the edit form. Same swap target. The result is the inline edit form, replacing the read-only row.
+* The delete button uses `hx-confirm` for an in-browser confirm dialog, `hx-swap="outerHTML swap:200ms"` for a 200 ms fade-out animation, and a DELETE that returns an empty body.
+
+The list partial is even simpler:
+
+[source,html]
+.grails-app/views/task/_taskRows.gsp
+----
+include::../snippets/grails-app/views/task/_taskRows.gsp[]
+----
+
+It iterates `_task.gsp` and falls back to a placeholder when the list is empty.

--- a/guides/grails-htmx/v8/guide/spaComparison.adoc
+++ b/guides/grails-htmx/v8/guide/spaComparison.adoc
@@ -1,0 +1,16 @@
+When does HTMX fit and when do you reach for an SPA?
+
+HTMX wins when:
+
+* The UI is fundamentally CRUD - lists, forms, partial updates, optimistic deletes. The task tracker in this guide is the canonical shape.
+* SEO matters - HTMX pages are server-rendered HTML on first paint, so search engines and link previews see the real content.
+* The team is more comfortable on the server than in JavaScript - HTMX shifts complexity away from the SPA's reactive state model into plain controller actions and GSP partials.
+* The deploy story is simpler when there is one bootJar instead of a backend + a frontend build pipeline.
+
+SPAs (React, Vue, Svelte) win when:
+
+* The UI is genuinely client-stateful - a real-time editor, a Kanban board with drag-and-drop, an analytics dashboard with cross-filter interactions. HTMX can do these but you fight the framework.
+* Offline-first matters - HTMX is built around server round-trips by design.
+* The same backend serves multiple frontends (web + native mobile) and you want a single JSON API surface for both.
+
+Most internal back-office apps land squarely in HTMX's sweet spot. The link:../grails-vite-spa/8/guide/index.html[Grails 8 + Vite SPA guide] covers the SPA path for the cases that need it.

--- a/guides/grails-htmx/v8/guide/taskDomain.adoc
+++ b/guides/grails-htmx/v8/guide/taskDomain.adoc
@@ -1,0 +1,9 @@
+A small Task domain class drives the UI:
+
+[source,groovy]
+.grails-app/domain/example/Task.groovy
+----
+include::../snippets/grails-app/domain/example/Task.groovy[]
+----
+
+`title blank: false, maxSize: 255` is the only constraint that matters for this guide; we will exercise it via the validation feedback path on inline edit. `dateCreated` is a GORM-managed timestamp. `static mapping { sort 'dateCreated'; order 'desc' }` makes new tasks appear at the top of the list.

--- a/guides/grails-htmx/v8/guide/urlMappings.adoc
+++ b/guides/grails-htmx/v8/guide/urlMappings.adoc
@@ -1,0 +1,9 @@
+Each HTMX endpoint is its own URL with an explicit method:
+
+[source,groovy]
+.grails-app/controllers/example/UrlMappings.groovy
+----
+include::../snippets/grails-app/controllers/example/UrlMappings.groovy[]
+----
+
+The repetition (`/tasks` for both index and create, distinguished by method) is intentional: HTMX requests carry their semantics in the HTTP method, exactly as REST does. Using `'/tasks'(resources: 'task')` would also work, but the explicit-route form makes the surface easier to read for an author who has never seen Grails' resource-mapping shorthand.

--- a/guides/grails-htmx/v8/guide/whatYouWillBuild.adoc
+++ b/guides/grails-htmx/v8/guide/whatYouWillBuild.adoc
@@ -1,0 +1,9 @@
+By the end of the guide your application will have:
+
+* A `Task` domain with `title` (required) and `done` (boolean), with sample data seeded by `BootStrap` so the page is non-empty on first load.
+* A `TaskController` with seven actions: `index` (full page), `search` (live filter), `create` (new task), `editForm` + `update` (inline edit), `toggle` (flip the done flag), `delete`. Every non-`index` action returns a tiny GSP partial, not a full page.
+* GSP partials at `_task.gsp`, `_taskRows.gsp`, and `_taskEdit.gsp` that the controller renders via `<g:render template="..."/>`. One partial per logical state.
+* The four core HTMX attributes (`hx-get`, `hx-post`, `hx-patch`, `hx-delete`) plus the swap targeting attributes (`hx-target`, `hx-swap`).
+* Live search via `hx-trigger="keyup changed delay:300ms"` so the rows partial refreshes after the user pauses typing.
+* Optimistic delete with confirm via `hx-confirm` and an outerHTML swap that animates the row out.
+* CSRF token forwarding configured globally so HTMX requests carry the right header on every POST/PATCH/DELETE.

--- a/guides/grails-htmx/v8/snippets/grails-app/controllers/example/TaskController.groovy
+++ b/guides/grails-htmx/v8/snippets/grails-app/controllers/example/TaskController.groovy
@@ -1,0 +1,76 @@
+package example
+
+import grails.gorm.transactions.Transactional
+import org.springframework.http.HttpStatus
+
+@Transactional(readOnly = true)
+class TaskController {
+
+    static allowedMethods = [
+            create: 'POST', update: 'PATCH', delete: 'DELETE', toggle: 'POST'
+    ]
+
+    /** Full page (index.gsp). */
+    def index() {
+        respond Task.list(params), model: [tasks: Task.list(params), q: '']
+    }
+
+    /** Live-search endpoint - returns just the rows partial. */
+    def search() {
+        String q = (params.q ?: '') as String
+        List<Task> rows = q ? Task.findAllByTitleIlike("%${q}%") : Task.list()
+        render template: 'taskRows', model: [tasks: rows]
+    }
+
+    /** Add a new task - returns the new row prepended to the list. */
+    @Transactional
+    def create() {
+        Task t = new Task(title: params.title)
+        if (!t.save()) {
+            response.status = HttpStatus.UNPROCESSABLE_ENTITY.value()
+            render template: 'taskForm', model: [task: t]
+            return
+        }
+        render template: 'task', model: [task: t]
+    }
+
+    /** Inline-edit endpoint - returns the edit form for a single row. */
+    def editForm(Long id) {
+        Task t = Task.get(id)
+        if (!t) { response.status = 404; return }
+        render template: 'taskEdit', model: [task: t]
+    }
+
+    /** Apply an inline edit - returns the read-only row partial. */
+    @Transactional
+    def update(Long id) {
+        Task t = Task.get(id)
+        if (!t) { response.status = 404; return }
+        t.properties = params
+        if (!t.save()) {
+            response.status = HttpStatus.UNPROCESSABLE_ENTITY.value()
+            render template: 'taskEdit', model: [task: t]
+            return
+        }
+        render template: 'task', model: [task: t]
+    }
+
+    /** Toggle the `done` flag - returns the row partial. */
+    @Transactional
+    def toggle(Long id) {
+        Task t = Task.get(id)
+        if (!t) { response.status = 404; return }
+        t.done = !t.done
+        t.save()
+        render template: 'task', model: [task: t]
+    }
+
+    /** Delete - HTMX swaps the row out via hx-target="closest tr" hx-swap="outerHTML". */
+    @Transactional
+    def delete(Long id) {
+        Task t = Task.get(id)
+        if (!t) { response.status = 404; return }
+        t.delete()
+        render ''
+    }
+}

--- a/guides/grails-htmx/v8/snippets/grails-app/controllers/example/UrlMappings.groovy
+++ b/guides/grails-htmx/v8/snippets/grails-app/controllers/example/UrlMappings.groovy
@@ -1,0 +1,20 @@
+package example
+
+class UrlMappings {
+
+    static mappings = {
+
+        '/tasks'(controller: 'task', action: 'index')
+        '/tasks/search'(controller: 'task', action: 'search')
+        '/tasks'(controller: 'task', action: 'create', method: 'POST')
+        '/tasks/$id/edit'(controller: 'task', action: 'editForm')
+        '/tasks/$id'(controller: 'task', action: 'update', method: 'PATCH')
+        '/tasks/$id'(controller: 'task', action: 'delete', method: 'DELETE')
+        '/tasks/$id/toggle'(controller: 'task', action: 'toggle', method: 'POST')
+
+        '/'(redirect: '/tasks')
+
+        '500'(view: '/error')
+        '404'(view: '/notFound')
+    }
+}

--- a/guides/grails-htmx/v8/snippets/grails-app/domain/example/Task.groovy
+++ b/guides/grails-htmx/v8/snippets/grails-app/domain/example/Task.groovy
@@ -1,0 +1,20 @@
+package example
+
+import grails.persistence.Entity
+
+@Entity
+class Task {
+
+    String  title
+    Boolean done = false
+    Date    dateCreated
+
+    static constraints = {
+        title blank: false, maxSize: 255
+    }
+
+    static mapping = {
+        sort 'dateCreated'
+        order 'desc'
+    }
+}

--- a/guides/grails-htmx/v8/snippets/grails-app/views/layouts/main.gsp
+++ b/guides/grails-htmx/v8/snippets/grails-app/views/layouts/main.gsp
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title><g:layoutTitle default="Grails + HTMX"/></title>
+    <asset:link rel="icon" href="favicon.ico" type="image/x-ico"/>
+    <asset:stylesheet src="application.css"/>
+
+    <%-- HTMX 2.x via CDN. For production, vendor the file under
+         grails-app/assets/javascripts/ and load via asset:javascript. --%>
+    <script src="https://unpkg.com/htmx.org@2.0.4"
+            integrity="sha384-HGfztofotfshcF7+8n44JQL2oJmowVChPTg48S+jvZoztPfvwD79OC/LTtG6dMp+"
+            crossorigin="anonymous"></script>
+
+    <g:layoutHead/>
+</head>
+<body>
+
+<nav class="navbar navbar-expand-lg bg-body border-bottom shadow-sm">
+    <div class="container-lg">
+        <a class="navbar-brand" href="${request.contextPath}/">
+            Grails + HTMX
+        </a>
+    </div>
+</nav>
+
+<g:layoutBody/>
+
+<asset:javascript src="application.js"/>
+</body>
+</html>

--- a/guides/grails-htmx/v8/snippets/grails-app/views/task/_task.gsp
+++ b/guides/grails-htmx/v8/snippets/grails-app/views/task/_task.gsp
@@ -1,0 +1,31 @@
+<li id="task-${task.id}" class="list-group-item d-flex align-items-center gap-3${task.done ? ' text-decoration-line-through text-body-secondary' : ''}">
+
+    <%-- Toggle the done flag with a single round trip --%>
+    <button type="button"
+            class="btn btn-sm ${task.done ? 'btn-success' : 'btn-outline-secondary'}"
+            hx-post="${createLink(controller: 'task', action: 'toggle', id: task.id)}"
+            hx-target="closest li"
+            hx-swap="outerHTML"
+            aria-label="Toggle done">
+        ${task.done ? '\u2713' : '\u00b7'}
+    </button>
+
+    <span class="flex-grow-1"
+          hx-get="${createLink(controller: 'task', action: 'editForm', id: task.id)}"
+          hx-target="closest li"
+          hx-swap="outerHTML"
+          role="button" tabindex="0"
+          title="Click to edit">
+        <g:fieldValue bean="${task}" field="title"/>
+    </span>
+
+    <button type="button"
+            class="btn btn-sm btn-outline-danger"
+            hx-delete="${createLink(controller: 'task', action: 'delete', id: task.id)}"
+            hx-target="closest li"
+            hx-swap="outerHTML swap:200ms"
+            hx-confirm="Delete '${task.title.encodeAsHTML()}'?"
+            aria-label="Delete">
+        \u2715
+    </button>
+</li>

--- a/guides/grails-htmx/v8/snippets/grails-app/views/task/_taskEdit.gsp
+++ b/guides/grails-htmx/v8/snippets/grails-app/views/task/_taskEdit.gsp
@@ -1,0 +1,23 @@
+<li id="task-${task.id}" class="list-group-item">
+    <form hx-patch="${createLink(controller: 'task', action: 'update', id: task.id)}"
+          hx-target="closest li"
+          hx-swap="outerHTML"
+          class="d-flex gap-2">
+        <input type="text"
+               name="title"
+               value="${task.title.encodeAsHTML()}"
+               class="form-control"
+               autofocus/>
+        <button type="submit" class="btn btn-primary btn-sm">Save</button>
+        <button type="button"
+                class="btn btn-outline-secondary btn-sm"
+                hx-get="${createLink(controller: 'task', action: 'show', id: task.id)}"
+                hx-target="closest li"
+                hx-swap="outerHTML">Cancel</button>
+    </form>
+    <g:if test="${task.errors?.hasErrors()}">
+        <ul class="text-danger small mt-2 mb-0">
+            <g:eachError bean="${task}"><li>${message(error: it).encodeAsHTML()}</li></g:eachError>
+        </ul>
+    </g:if>
+</li>

--- a/guides/grails-htmx/v8/snippets/grails-app/views/task/_taskRows.gsp
+++ b/guides/grails-htmx/v8/snippets/grails-app/views/task/_taskRows.gsp
@@ -1,0 +1,6 @@
+<g:each in="${tasks}" var="task">
+    <g:render template="task" model="[task: task]"/>
+</g:each>
+<g:if test="${!tasks}">
+    <li class="list-group-item text-body-secondary">No tasks yet. Add one above.</li>
+</g:if>

--- a/guides/grails-htmx/v8/snippets/grails-app/views/task/index.gsp
+++ b/guides/grails-htmx/v8/snippets/grails-app/views/task/index.gsp
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+<head>
+    <title>HTMX Task Tracker</title>
+    <meta name="layout" content="main"/>
+</head>
+<body>
+
+<main class="container-lg py-4">
+    <h1 class="h3 mb-3">Tasks</h1>
+
+    <%-- Add a task --%>
+    <form id="taskForm"
+          hx-post="${createLink(controller: 'task', action: 'create')}"
+          hx-target="#taskList"
+          hx-swap="afterbegin"
+          hx-on::after-request="this.reset()"
+          class="d-flex gap-2 mb-3">
+        <input type="text" name="title" placeholder="What needs doing?" required class="form-control"/>
+        <button type="submit" class="btn btn-primary">Add</button>
+    </form>
+
+    <%-- Live search --%>
+    <input type="text"
+           name="q"
+           placeholder="Search tasks..."
+           class="form-control mb-3"
+           hx-get="${createLink(controller: 'task', action: 'search')}"
+           hx-trigger="keyup changed delay:300ms"
+           hx-target="#taskList"
+           hx-swap="innerHTML"/>
+
+    <%-- The list. HTMX swaps individual rows in/out of this <ul>. --%>
+    <ul id="taskList" class="list-group">
+        <g:render template="taskRows" model="[tasks: tasks]"/>
+    </ul>
+</main>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds the **HTMX with Grails 8** guide as the fifth Grails 8 sample-app-flavour guide and the second greenfield one (after the Tailwind PR #493). Following PRs #479, #493, #494, #495, #496.

A worked task tracker that demonstrates the HTMX recipe on a Grails 8 GSP backend: server-rendered first paint, then `hx-get/post/patch/delete` round-trips that swap small GSP partial fragments into well-defined slots in the DOM. No SPA, no JSON, no client-state framework.

## Greenfield - no upstream rename

The new `grails-guides/grails-htmx` repository was created public with `grails8` as its default branch. There were no overlapping legacy repos to rename.

## What's in the PR

- `conf/guides.yml` - new `grails-htmx` registry entry, alphabetical insertion between `grails-google-home` and `grails-javamelody`.
- `guides/grails-htmx/v8/guide/*.adoc` - 14 chapters.
- `guides/grails-htmx/v8/snippets/` - vendored Task domain, TaskController (7 actions), UrlMappings, `main.gsp` layout (with the HTMX 2.x script tag), and three GSP partials (`_task.gsp` row, `_taskRows.gsp` list, `_taskEdit.gsp` edit form).

## Upstream sample app

[`grails-guides/grails-htmx`](https://github.com/grails-guides/grails-htmx) on the `grails8` branch contains the standard `initial/` + `complete/` layout. `initial/` is a vanilla Grails 8 `web` starter. `complete/` adds the HTMX-driven task tracker.

## Verification

- `./gradlew validateGuides -PvalidationMode=both` returns **86 guides, 0 errors**.
- `./gradlew renderGuide_grails_htmx_8 --rerun-tasks --no-configuration-cache` renders all 14 chapter HTML pages, no Unresolved directive errors.

## Notes for reviewers

- This is the second greenfield Grails 8 PR (after #493 Tailwind). The other PRs in the Grails 8 series (#494 Docker, #495 CI/CD, #496 REST) renamed an existing legacy repo. Neither path is preferred a priori - greenfield where the topic is new, rename where a legacy repo's name no longer matches its content.
- The HTMX vs SPA comparison chapter forward-references the upcoming `grails-vite-spa` guide, which is the next PR in the series.
- The CSRF chapter shows the standard `htmx:configRequest` hook for forwarding a Grails synchronizer token; the in-app sample app keeps the token plumbing minimal so the focus stays on the HTMX patterns.