### PR TITLE
Reference Testcontainers BOM version from gradle.properties in guide prose

### DIFF
--- a/guides/grails-rest-library/v8/guide/testing.adoc
+++ b/guides/grails-rest-library/v8/guide/testing.adoc
@@ -11,10 +11,18 @@ testImplementation "org.apache.grails:grails-testing-support-datamapping"
 testImplementation "org.apache.grails:grails-testing-support-views-gson"
 testImplementation "org.apache.grails:grails-testing-support-web"
 testImplementation "org.spockframework:spock-core"
-testImplementation platform("org.testcontainers:testcontainers-bom:1.20.4")
+testImplementation platform("org.testcontainers:testcontainers-bom:$testcontainersVersion")
 testImplementation "org.testcontainers:postgresql"
 testImplementation "org.testcontainers:spock"
 testImplementation "org.testcontainers:testcontainers"
+----
+
+The `testcontainersVersion` is kept in `gradle.properties` alongside `grailsVersion`, so the version lives in one place:
+
+[source,properties]
+.gradle.properties
+----
+testcontainersVersion=1.20.4
 ----
 
 Because this app uses the database-migration plugin, an empty `changelog.groovy` means GORM will not auto-create the schema in the test environment. The test profile therefore turns the migration off and lets GORM create the schema directly:

--- a/guides/grails-vite-spa/v8/guide/testing.adoc
+++ b/guides/grails-vite-spa/v8/guide/testing.adoc
@@ -11,10 +11,18 @@ testImplementation "org.apache.grails:grails-testing-support-datamapping"
 testImplementation "org.apache.grails:grails-testing-support-views-gson"
 testImplementation "org.apache.grails:grails-testing-support-web"
 testImplementation "org.spockframework:spock-core"
-testImplementation platform("org.testcontainers:testcontainers-bom:1.20.4")
+testImplementation platform("org.testcontainers:testcontainers-bom:$testcontainersVersion")
 testImplementation "org.testcontainers:postgresql"
 testImplementation "org.testcontainers:spock"
 testImplementation "org.testcontainers:testcontainers"
+----
+
+The `testcontainersVersion` is kept in `backend/gradle.properties` alongside `grailsVersion`, so the version lives in one place:
+
+[source,properties]
+.backend/gradle.properties
+----
+testcontainersVersion=1.20.4
 ----
 
 == Unit: domain and controller


### PR DESCRIPTION
Follow-up to #510. The sample apps now keep the Testcontainers BOM version in `gradle.properties` (as `testcontainersVersion`) instead of hardcoding it in `build.gradle`, matching how `grailsVersion` is managed and keeping the version in one place.

This updates the two guide testing chapters that showed the version inline:

- `grails-rest-library` testing chapter -> `platform("org.testcontainers:testcontainers-bom:\")` + a `gradle.properties` snippet
- `grails-vite-spa` testing chapter -> same, referencing `backend/gradle.properties`

The matching `grails-guides/*` sample apps (`grails-spock-test-tour`, `grails-rest-library`, `grails-github-actions-cicd`, `grails-vite-spa`, `grails-docker-bootbuildimage`) were updated on their `grails8` branches.

`validateGuides`: 93 guides, 0 errors. Both guides re-rendered cleanly.

Assisted-by: claude-code:claude-opus-4-7
