### PR TITLE
ci: audit and update GitHub Actions to ASF-approved versions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,22 +16,23 @@ jobs:
       WORKSPACE: ${{ github.workspace }}
       GRADLE_OPTS: -Xmx1500m -Dfile.encoding=UTF-8
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: liberica
           java-version: 17
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
+          cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
           develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       - name: Run Tests
         run: |
           (set -x; ./gradlew clean check --no-daemon)
       - name: Publish Test Report
         if: failure()
-        uses: scacap/action-surefire-report@5609ce4db72c09db044803b344a8968fd1f315da # v1.9.1
+        uses: scacap/action-surefire-report@3dacff26879cd2a7f2160d101254032a3707fe6f # v1.12.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,21 +30,22 @@ jobs:
           sudo rm -rf /opt/hostedtoolcache/CodeQL
 
           df -h
-      - uses: actions/checkout@v6
-      - uses: actions/cache@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: liberica
           java-version: 17
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
+          cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
           develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       - name: Publish Main Site
         # The vendored PublishGuideTask is not configuration-cache safe.

--- a/.github/workflows/release-companion.yml
+++ b/.github/workflows/release-companion.yml
@@ -28,11 +28,11 @@ jobs:
       GIT_USER_EMAIL: grails-build@users.noreply.github.com
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,11 @@ jobs:
       GIT_USER_EMAIL: grails-build@users.noreply.github.com
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/rendersite.yml
+++ b/.github/workflows/rendersite.yml
@@ -4,15 +4,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: 17
           distribution: liberica
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
+          cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
           develocity-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       - name: Render HTML for Site
         run: ./gradlew renderSite


### PR DESCRIPTION
## What

Audit of every GitHub Action used in this repository against the [ASF approved actions allow-list](https://github.com/apache/infrastructure-actions/blob/main/actions.yml), updating each to its current approved version and pinning every external action to a full commit SHA with a trailing comment naming the version it resolves to.

This mirrors the audit performed on grails-core in apache/grails-core#15690 and brings this repository back onto supported, allow-list-approved action versions.

## Why (setup-gradle)

The primary driver is `gradle/actions/setup-gradle`:

- The previously-used SHAs were either never on the ASF allow-list or are scheduled to **expire from it on 2026-06-20**.
- `gradle/actions` `v6.0.0` moved caching into a proprietary `enhanced` provider governed by [Gradle's commercial Terms of Use](https://gradle.com/legal/terms-of-use/). `v6.1.0` reintroduced an MIT-licensed `basic` cache provider.

Standardizing on the approved **`v6.1.0`** SHA with **`cache-provider: basic`** (3 steps) keeps us on a supported version while caching stays MIT-licensed. Each `cache-provider` line carries an inline comment documenting the distinction.

## Changes

| Action | Before | After (pinned SHA # version) |
|--------|--------|------------------------------|
| `actions/checkout` | v4, v6 | `de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2` |
| `actions/setup-java` | v4, v5 | `be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0` |
| `gradle/actions/setup-gradle` | 017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2, 0723195856401067f7a2779048b490ace7a47d7c # v5.0.2 | `50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0` |
| `scacap/action-surefire-report` | 5609ce4db72c09db044803b344a8968fd1f315da # v1.9.1 | `3dacff26879cd2a7f2160d101254032a3707fe6f # v1.12.0` |
| `actions/cache` | v5 | `27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5` |

Plus `cache-provider: basic` added to all 3 `setup-gradle` steps.

First-party `apache/grails-github-actions/*` references and local `./.github/actions/*` composites are intentionally left unchanged.

## Verification

- Every external action is SHA-pinned with a `# version` comment; the only non-SHA refs remaining are the first-party `apache/*` `@asf` ones and local composite actions.
- All modified workflow YAML files parse cleanly.