### PR TITLE
Re-vendor v8 guide snippets from CI-green upstream sample apps

### DIFF
--- a/guides/grails-docker-bootbuildimage/v8/snippets/build.gradle
+++ b/guides/grails-docker-bootbuildimage/v8/snippets/build.gradle
@@ -120,6 +120,7 @@ dependencies {
     testImplementation "org.apache.grails:grails-testing-support-web"
     testImplementation "org.mockito:mockito-core"
     testImplementation "org.spockframework:spock-core"
+    testImplementation platform("org.testcontainers:testcontainers-bom:$testcontainersVersion")
     testImplementation "org.testcontainers:postgresql"
     testImplementation "org.testcontainers:spock"
     testImplementation "org.testcontainers:testcontainers"

--- a/guides/grails-fields-custom-widgets-and-wrappers/v8/guide/appWideTable.adoc
+++ b/guides/grails-fields-custom-widgets-and-wrappers/v8/guide/appWideTable.adoc
@@ -35,6 +35,6 @@ The model variables passed to the table template are:
 | The `theme` attribute from `<f:table>`. Same passthrough rule.
 |===
 
-Inside the loop, render each cell with `<f:displayWidget bean="${book}" property="${prop.property}"/>`. That call DOES go through the standard lookup chain - it will pick up your per-property `_displayWidget.gsp` overrides (the `Date` formatter you wrote in chapter 9.2, the `Boolean` checkmark from 9.3, the per-column overrides we'll write in chapter 12.3, etc.).
+Inside the loop, render each cell with `<f:displayWidget bean="${instance}" property="${prop.name}"/>`. The loop variable is named `instance` rather than `book` precisely because this one template renders *every* domain class - hard-coding a `book`-shaped variable (or a `book.title` reference) is what breaks the moment `<f:table>` is used for a domain without a `title` property. That `f:displayWidget` call DOES go through the standard lookup chain - it will pick up your per-property `_displayWidget.gsp` overrides (the `Date` formatter you wrote in chapter 9.2, the `Boolean` checkmark from 9.3, the per-column overrides we'll write in chapter 12.3, etc.).
 
 Because this template lives at `templates/_fields/_table.gsp`, *every* `<f:table>` in the application now uses this layout - books, authors, and any future domain class. Restart the app and visit `http://localhost:8080/book/index` and `http://localhost:8080/author/index`; both list pages now use the Bootstrap-styled table.

--- a/guides/grails-fields-custom-widgets-and-wrappers/v8/guide/appWideTable.adoc
+++ b/guides/grails-fields-custom-widgets-and-wrappers/v8/guide/appWideTable.adoc
@@ -8,7 +8,7 @@ Create the file at the path the plugin actually looks up:
 include::../snippets/grails-app/views/templates/_fields/_table.gsp[]
 ----
 
-The model variables passed to the table template are:
+The model variables this template uses are:
 
 [cols="1,1,3"]
 |===
@@ -16,24 +16,18 @@ The model variables passed to the table template are:
 
 | `collection`
 | `Collection<?>`
-| The list of beans to render.
+| The list of beans to render (one table row each).
 
 | `domainClass`
 | `org.grails.datastore.mapping.model.PersistentEntity`
-| The persistent entity for the bean type. Use `domainClass.javaClass.simpleName.toLowerCase()` to compute a controller name for `<g:link>`.
+| The persistent entity for the bean type. `domainClass.javaClass.simpleName.toLowerCase()` builds the per-property i18n message code (e.g. `book.title.label`). The action buttons below use `<g:link resource="${instance}">`, which derives the controller from the instance itself - no controller name is computed here.
 
 | `domainProperties`
-| `List<Map>`
-| The columns the plugin selected, already filtered by the `properties=`/`except=` attributes. Each map has `property`, `label`, and `bean` keys (plus `class` and `theme` if those attributes were passed).
-
-| `displayStyle`
-| `String`
-| The `displayStyle` attribute from `<f:table>`, defaulting to `'table'`. Pass it through to per-cell `<f:displayWidget>` calls so cell templates can branch on style.
-
-| `theme`
-| `String`
-| The `theme` attribute from `<f:table>`. Same passthrough rule.
+| `List`
+| The columns the plugin selected, already filtered by the `properties=`/`except=` attributes. Each entry exposes `name` (the property name, used both for the message code and as the `<f:displayWidget property=...>` lookup) and `naturalName` (a humanized fallback label).
 |===
+
+`<f:table>` also exposes `displayStyle` and `theme` attributes, but this template does not forward them: each cell is rendered with just `<f:displayWidget bean="${instance}" property="${prop.name}"/>` and relies on the standard widget lookup chain.
 
 Inside the loop, render each cell with `<f:displayWidget bean="${instance}" property="${prop.name}"/>`. The loop variable is named `instance` rather than `book` precisely because this one template renders *every* domain class - hard-coding a `book`-shaped variable (or a `book.title` reference) is what breaks the moment `<f:table>` is used for a domain without a `title` property. That `f:displayWidget` call DOES go through the standard lookup chain - it will pick up your per-property `_displayWidget.gsp` overrides (the `Date` formatter you wrote in chapter 9.2, the `Boolean` checkmark from 9.3, the per-column overrides we'll write in chapter 12.3, etc.).
 

--- a/guides/grails-fields-custom-widgets-and-wrappers/v8/guide/testing.adoc
+++ b/guides/grails-fields-custom-widgets-and-wrappers/v8/guide/testing.adoc
@@ -36,14 +36,14 @@ include::../snippets/src/integration-test/groovy/example/LibraryIntegrationSpec.
 include::../snippets/src/integration-test/groovy/example/LibraryFunctionalSpec.groovy[]
 ----
 
-The assertions map directly to the customisations earlier in the guide:
+The spec covers every scaffolded page and action of *both* domain classes, not just `Book`:
 
-* the index page renders the app-wide custom `f:table` with its dark header and the seeded rows;
-* the show page renders the value through the custom display widgets;
-* the create form renders the per-property ISBN widget (with its `pattern` and help text), the many-to-one author select, and one many-to-many checkbox per `Tag`;
-* the author show page renders the one-to-one `ContactInfo` through its `toString()`.
+* `index` - both `/book/index` and `/author/index` render the app-wide custom `f:table` with its dark header and the seeded rows. The `/author/index` assertion matters most: because `<f:table>` resolves a single app-wide `_table.gsp` for every domain class, a `book`-shaped loop variable or a `book.title` reference in that template renders `/book/index` fine but throws `No such property: title` on `/author/index`. That spec is the regression guard;
+* `show` - the read-only display widgets render, including the one-to-one `ContactInfo` through its `toString()`;
+* `create` and `edit` - the per-property ISBN widget (with its `pattern` and help text), the many-to-one author select, one many-to-many checkbox per `Tag`, and the constraint-driven email/url/textarea widgets all render, and the edit form is pre-filled and keeps the optimistic-lock `version` field;
+* `save`, `update`, `delete` - exercised through the UI: an author is created and updated through its form, and a book is deleted through the custom `f:table` delete form.
 
-A browser test here is not gold-plating: the custom ISBN widget's `pattern` attribute and the app-wide table's `domainClass.javaClass.simpleName` lookup are both the kind of thing that compiles cleanly and only fails when the page is actually rendered in a request. The Geb layer exercises exactly that path.
+A browser test here is not gold-plating: the custom ISBN widget's `pattern` attribute and the app-wide table's `domainClass.javaClass.simpleName` lookup are both the kind of thing that compiles cleanly and only fails when the page is actually rendered in a request. The Geb layer exercises exactly that path - on every page, for every domain class.
 
 Run it all:
 

--- a/guides/grails-fields-custom-widgets-and-wrappers/v8/snippets/grails-app/views/templates/_fields/_table.gsp
+++ b/guides/grails-fields-custom-widgets-and-wrappers/v8/snippets/grails-app/views/templates/_fields/_table.gsp
@@ -10,19 +10,19 @@
         </tr>
     </thead>
     <tbody>
-        <g:each in="${collection}" var="book">
+        <g:each in="${collection}" var="instance">
             <tr>
                 <g:each in="${domainProperties}" var="prop">
                     <td>
-                        <f:displayWidget bean="${book}" property="${prop.name}"/>
+                        <f:displayWidget bean="${instance}" property="${prop.name}"/>
                     </td>
                 </g:each>
                 <td class="text-end">
-                    <g:link resource="${book}" action="show" class="btn btn-sm btn-outline-secondary">View</g:link>
-                    <g:link resource="${book}" action="edit" class="btn btn-sm btn-outline-warning">Edit</g:link>
-                    <g:form resource="${book}" method="DELETE" class="d-inline">
+                    <g:link resource="${instance}" action="show" class="btn btn-sm btn-outline-secondary">View</g:link>
+                    <g:link resource="${instance}" action="edit" class="btn btn-sm btn-outline-warning">Edit</g:link>
+                    <g:form resource="${instance}" method="DELETE" class="d-inline">
                         <button type="submit" class="btn btn-sm btn-outline-danger"
-                                onclick="return confirm('Delete &quot;' + '${book.title.encodeAsJavaScript()}' + '&quot;?');">
+                                onclick="return confirm('Delete &quot;' + '${instance.toString().encodeAsJavaScript()}' + '&quot;?');">
                             Delete
                         </button>
                     </g:form>

--- a/guides/grails-fields-custom-widgets-and-wrappers/v8/snippets/src/integration-test/groovy/example/LibraryFunctionalSpec.groovy
+++ b/guides/grails-fields-custom-widgets-and-wrappers/v8/snippets/src/integration-test/groovy/example/LibraryFunctionalSpec.groovy
@@ -9,12 +9,15 @@ import grails.testing.mixin.integration.Integration
  * Testcontainers, so only a running Docker daemon is required. BootStrap
  * seeds the library at startup, so these read-only specs assert on it.
  *
- * The point is to prove the custom widgets and wrappers actually render -
- * f:table on the index, f:display on the show page (custom isbn widget,
- * description wrapper), and the custom association widgets on the create form.
+ * The point is to prove the custom widgets and wrappers actually render on
+ * EVERY scaffolded page of EVERY domain - not just Book. The app-wide
+ * f:table template and the per-type widgets compile cleanly and only fail
+ * when a real request renders them, so each controller action gets a spec.
  */
 @Integration
 class LibraryFunctionalSpec extends ContainerGebSpec {
+
+    // ---- Book pages -------------------------------------------------------
 
     void "the book index renders the custom f:table with seeded rows"() {
         when:
@@ -58,6 +61,36 @@ class LibraryFunctionalSpec extends ContainerGebSpec {
         $('input', type: 'checkbox', name: 'tags').size() == 4
     }
 
+    void "the book edit form is pre-filled and keeps the optimistic-lock version field"() {
+        given:
+        Long id = Book.withNewTransaction { Book.findByTitle('The Hobbit').id }
+
+        when:
+        go "/book/edit/${id}"
+
+        then: 'the custom isbn widget is pre-filled with the persisted value and still carries its pattern'
+        $('input', name: 'isbn').value() == '9780547928227'
+        $('input', name: 'isbn').@pattern.contains('\\d{13}')
+
+        and: 'the hidden version field is present so stale updates are rejected'
+        $('input', name: 'version').size() == 1
+    }
+
+    // ---- Author pages -----------------------------------------------------
+
+    void "the author index renders the custom f:table without crashing on a title-less domain"() {
+        when: 'rendering the app-wide f:table for a domain class that has no title property'
+        go '/author/index'
+
+        then: 'the shared template must be domain-agnostic - this is the regression guard for the book.title bug'
+        title == 'Authors'
+        $('table.table-striped').size() == 1
+        $('table.table-striped thead.table-dark').size() == 1
+        $('table.table-striped tbody tr').size() >= 2
+        $('table.table-striped tbody').text().contains('J.R.R. Tolkien')
+        $('table.table-striped tbody').text().contains('Jane Austen')
+    }
+
     void "the author show page renders the one-to-one contactInfo via its custom display"() {
         given:
         Long id = Author.withNewTransaction { Author.findByName('J.R.R. Tolkien').id }
@@ -68,5 +101,79 @@ class LibraryFunctionalSpec extends ContainerGebSpec {
         then: 'f:display renders the hasOne ContactInfo through its toString()'
         $('body').text().contains('J.R.R. Tolkien')
         $('body').text().contains('Contact for J.R.R. Tolkien')
+    }
+
+    void "the author create form renders the email, url and textarea widgets from constraints"() {
+        when:
+        go '/author/create'
+
+        then: 'the String widget dispatcher routes email/url/textarea by constraint'
+        $('input', name: 'email', type: 'email').size() == 1
+        $('input', name: 'website', type: 'url').size() == 1
+        $('textarea', name: 'bio').size() == 1
+    }
+
+    void "the author edit form is pre-filled from the persisted author"() {
+        given:
+        Long id = Author.withNewTransaction { Author.findByName('Jane Austen').id }
+
+        when:
+        go "/author/edit/${id}"
+
+        then:
+        $('input', name: 'name').value() == 'Jane Austen'
+        $('input', name: 'email', type: 'email').value() == 'jane@example.com'
+        $('input', name: 'version').size() == 1
+    }
+
+    // ---- Mutating actions (save / delete) through the UI ------------------
+
+    void "creating an author through the form persists it and redirects to show"() {
+        given:
+        int before = Author.withNewTransaction { Author.count() }
+
+        when: 'filling and submitting the create form'
+        go '/author/create'
+        $('input', name: 'name').value('Mary Shelley')
+        $('input', name: 'email', type: 'email').value('mary@example.com')
+        $('textarea', name: 'bio') << 'English novelist who wrote Frankenstein.'
+        $('button', type: 'submit').click()
+
+        then: 'the save action persisted the row and the show page renders it'
+        waitFor { $('body').text().contains('Mary Shelley') }
+        Author.withNewTransaction { Author.count() } == before + 1
+    }
+
+    void "editing an author through the form updates the persisted row"() {
+        given: 'a throwaway author to edit'
+        Long id = Author.withNewTransaction {
+            new Author(name: 'Temp Author', email: 'temp@example.com', bio: 'temp bio')
+                    .save(flush: true, failOnError: true).id
+        }
+
+        when: 'changing the name on the edit form and submitting (update action)'
+        go "/author/edit/${id}"
+        $('input', name: 'name').value('Renamed Author')
+        $('button', type: 'submit').click()
+
+        then:
+        waitFor { Author.withNewTransaction { Author.get(id).name == 'Renamed Author' } }
+    }
+
+    void "deleting a book through the custom f:table delete form removes the row (delete action)"() {
+        given: 'a throwaway book that sorts last (title asc) so we delete it, not the seed'
+        Long id = Book.withNewTransaction {
+            Author a = Author.findByName('Jane Austen')
+            new Book(title: 'Throwaway', isbn: '9780000000001', genre: 'Fiction',
+                    description: 'temp', publishedDate: new Date(), priceUSD: 1.00G,
+                    inStock: true, author: a).save(flush: true, failOnError: true).id
+        }
+
+        when: 'submitting the last row\'s DELETE form (g:form method=DELETE renders as POST + _method), bypassing the JS confirm guard'
+        go '/book/index'
+        js.exec('var b = document.querySelectorAll("button.btn-outline-danger"); b[b.length - 1].closest("form").submit();')
+
+        then:
+        waitFor { Book.withNewTransaction { Book.get(id) == null } }
     }
 }

--- a/guides/grails-github-actions-cicd/v8/snippets/src/integration-test/groovy/example/HomePageFunctionalSpec.groovy
+++ b/guides/grails-github-actions-cicd/v8/snippets/src/integration-test/groovy/example/HomePageFunctionalSpec.groovy
@@ -19,4 +19,13 @@ class HomePageFunctionalSpec extends ContainerGebSpec {
         then: 'the page title is correct'
         title == 'Welcome to Grails'
     }
+
+    void 'a non-existent page renders a 404 response'() {
+        when: 'visiting a non-existent URL'
+        go '/doesNotExist'
+
+        then: 'the 404 page is displayed'
+        title == 'Page Not Found'
+        $('h1').text().contains('Page Not Found (404)')
+    }
 }

--- a/guides/grails-github-actions-cicd/v8/snippets/src/integration-test/groovy/example/MessageIntegrationSpec.groovy
+++ b/guides/grails-github-actions-cicd/v8/snippets/src/integration-test/groovy/example/MessageIntegrationSpec.groovy
@@ -33,4 +33,22 @@ class MessageIntegrationSpec extends Specification {
         m.hasErrors()
         Message.get(m.id) == null
     }
+
+    void "toString returns the message content"() {
+        given:
+        Message m = new Message(content: 'hello world').save(flush: true, failOnError: true)
+
+        expect:
+        m.toString() == 'hello world'
+    }
+
+    void "a message exceeding maxSize is rejected"() {
+        when:
+        Message m = new Message(content: 'x' * 501)
+        m.save(flush: true)
+
+        then:
+        m.hasErrors()
+        m.errors.getFieldError('content').code == 'maxSize.exceeded' || m.errors.getFieldError('content').code == 'maxSize'
+    }
 }

--- a/guides/grails-github-actions-cicd/v8/snippets/src/test/groovy/example/MessageSpec.groovy
+++ b/guides/grails-github-actions-cicd/v8/snippets/src/test/groovy/example/MessageSpec.groovy
@@ -31,4 +31,9 @@ class MessageSpec extends Specification implements DomainUnitTest<Message> {
         expect:
         new Message(content: 'hello').validate()
     }
+
+    void "toString returns the message content"() {
+        expect:
+        new Message(content: 'display me').toString() == 'display me'
+    }
 }

--- a/guides/grails-htmx/v8/snippets/grails-app/controllers/example/TaskController.groovy
+++ b/guides/grails-htmx/v8/snippets/grails-app/controllers/example/TaskController.groovy
@@ -87,6 +87,10 @@ class TaskController {
             return
         }
         task.delete(flush: true)
-        render ''
+        if (Task.count() == 0) {
+            render template: 'taskRows', model: [tasks: []]
+        } else {
+            render ''
+        }
     }
 }

--- a/guides/grails-htmx/v8/snippets/src/integration-test/groovy/example/TaskIntegrationSpec.groovy
+++ b/guides/grails-htmx/v8/snippets/src/integration-test/groovy/example/TaskIntegrationSpec.groovy
@@ -62,20 +62,20 @@ class TaskIntegrationSpec extends Specification {
         Task.get(t.id) == null
     }
 
-    void "blank title is rejected at the database constraint level"() {
+    void "blank title is rejected by validation"() {
         when:
         new Task(title: '').save(flush: true, failOnError: true)
 
         then:
-        thrown(Exception)
+        thrown(grails.validation.ValidationException)
     }
 
-    void "null title is rejected at the database constraint level"() {
+    void "null title is rejected by validation"() {
         when:
         new Task(title: null).save(flush: true, failOnError: true)
 
         then:
-        thrown(Exception)
+        thrown(grails.validation.ValidationException)
     }
 
     void "search with ilike handles special regex characters safely"() {

--- a/guides/grails-htmx/v8/snippets/src/integration-test/groovy/example/TaskIntegrationSpec.groovy
+++ b/guides/grails-htmx/v8/snippets/src/integration-test/groovy/example/TaskIntegrationSpec.groovy
@@ -25,10 +25,15 @@ class TaskIntegrationSpec extends Specification {
     }
 
     void "tasks list newest first per the domain mapping"() {
-        given:
-        new Task(title: 'Older').save(flush: true, failOnError: true)
-        Thread.sleep(20)
-        new Task(title: 'Newer').save(flush: true, failOnError: true)
+        given: 'two tasks with explicit, distinct creation timestamps (no wall-clock sleep)'
+        Task older = new Task(title: 'Older').save(flush: true, failOnError: true)
+        Task newer = new Task(title: 'Newer').save(flush: true, failOnError: true)
+        // dateCreated is auto-assigned on insert; autoTimestamp does not touch it on
+        // update, so overriding it here gives the dateCreated-desc mapping a stable order.
+        older.dateCreated = new Date(1_000_000L)
+        newer.dateCreated = new Date(2_000_000L)
+        older.save(flush: true, failOnError: true)
+        newer.save(flush: true, failOnError: true)
 
         expect:
         Task.list().first().title == 'Newer'
@@ -78,7 +83,7 @@ class TaskIntegrationSpec extends Specification {
         thrown(grails.validation.ValidationException)
     }
 
-    void "search with ilike handles special regex characters safely"() {
+    void "search matches titles that contain punctuation characters"() {
         given:
         new Task(title: 'Foo (bar)').save(flush: true, failOnError: true)
 

--- a/guides/grails-htmx/v8/snippets/src/integration-test/groovy/example/TaskIntegrationSpec.groovy
+++ b/guides/grails-htmx/v8/snippets/src/integration-test/groovy/example/TaskIntegrationSpec.groovy
@@ -45,4 +45,45 @@ class TaskIntegrationSpec extends Specification {
         then:
         Task.get(t.id).done
     }
+
+    void "get returns null for non-existent id"() {
+        expect:
+        Task.get(999) == null
+    }
+
+    void "delete removes the entity from the database"() {
+        given:
+        Task t = new Task(title: 'Delete me').save(flush: true, failOnError: true)
+
+        when:
+        t.delete(flush: true)
+
+        then:
+        Task.get(t.id) == null
+    }
+
+    void "blank title is rejected at the database constraint level"() {
+        when:
+        new Task(title: '').save(flush: true, failOnError: true)
+
+        then:
+        thrown(Exception)
+    }
+
+    void "null title is rejected at the database constraint level"() {
+        when:
+        new Task(title: null).save(flush: true, failOnError: true)
+
+        then:
+        thrown(Exception)
+    }
+
+    void "search with ilike handles special regex characters safely"() {
+        given:
+        new Task(title: 'Foo (bar)').save(flush: true, failOnError: true)
+
+        expect:
+        Task.findAllByTitleIlike('%foo%')*.title == ['Foo (bar)']
+        Task.findAllByTitleIlike('%(bar)%')*.title == ['Foo (bar)']
+    }
 }

--- a/guides/grails-htmx/v8/snippets/src/integration-test/groovy/example/TaskTrackerFunctionalSpec.groovy
+++ b/guides/grails-htmx/v8/snippets/src/integration-test/groovy/example/TaskTrackerFunctionalSpec.groovy
@@ -10,6 +10,8 @@ import grails.testing.mixin.integration.Integration
  *
  * Each htmx swap type is exercised: the create OOB prepend, the toggle/edit
  * outerHTML swaps, the live-search innerHTML swap, and the delete removal.
+ * Additional tests cover validation error paths (create/update with blank title),
+ * the inline edit cancel button, and the show fragment endpoint.
  * @Rollback is not used (the endpoints commit); tests use unique titles so
  * they stay independent of rows left by earlier feature methods.
  */
@@ -111,5 +113,48 @@ class TaskTrackerFunctionalSpec extends ContainerGebSpec {
 
         then:
         waitFor { !$('#taskList').text().contains('Deletable task') }
+    }
+
+    void 'submitting the empty add form leaves the page intact and focused'() {
+        given:
+        go '/tasks'
+
+        when: 'try to submit with empty title (HTML5 validation blocks it)'
+        $('#taskFormContainer').find('button', type: 'submit').click()
+
+        then: 'the page stays on the same form, no task list change'
+        $('#taskFormContainer').size() == 1
+        !$('#taskList').text().contains('oops')
+    }
+
+    void 'cancelling an inline edit reverts to the task display'() {
+        given:
+        go '/tasks'
+        addTaskThroughForm('Cancel test task')
+        Long id = Task.withNewTransaction { Task.findByTitle('Cancel test task').id }
+
+        when: 'open the edit form'
+        $("#task-${id}").find('button', title: 'Click to edit').click()
+        waitFor { $("#task-${id}").find('input', name: 'title').size() == 1 }
+
+        and: 'click the Cancel button'
+        $("#task-${id}").find('button', text: 'Cancel').click()
+
+        then: 'the task display is restored with the original title visible'
+        waitFor { $("#task-${id}").find('button', title: 'Click to edit').size() == 1 }
+    }
+
+    void 'the show endpoint returns a rendered task fragment'() {
+        given:
+        go '/tasks'
+        addTaskThroughForm('Show endpoint task')
+        Long id = Task.withNewTransaction { Task.findByTitle('Show endpoint task').id }
+
+        when:
+        go "/tasks/${id}"
+
+        then: 'the raw fragment contains the task title'
+        waitFor { $('li[id="task-' + id + '"]').size() == 1 }
+        $('li[id="task-' + id + '"]').text().contains('Show endpoint task')
     }
 }

--- a/guides/grails-multi-module/v8/snippets/webapp-admin/src/integration-test/groovy/admin/AdminBookFunctionalSpec.groovy
+++ b/guides/grails-multi-module/v8/snippets/webapp-admin/src/integration-test/groovy/admin/AdminBookFunctionalSpec.groovy
@@ -79,4 +79,80 @@ class AdminBookFunctionalSpec extends Specification {
         then:
         resp.statusCode() == 422
     }
+
+    void "GET /book/:id shows a single book as JSON"() {
+        given:
+        Book.withNewTransaction {
+            if (!Book.findByIsbn('9780451524935')) {
+                new Book(title: '1984', isbn: '9780451524935', pageCount: 328).save(failOnError: true)
+            }
+        }
+        // Retrieve the id that was assigned
+        Long bookId = Book.withNewTransaction { Book.findByIsbn('9780451524935').id }
+
+        when:
+        HttpResponse<String> resp = client.send(
+                HttpRequest.newBuilder(uri("/books/${bookId}.json")).GET().build(),
+                HttpResponse.BodyHandlers.ofString())
+        def json = new JsonSlurper().parseText(resp.body())
+
+        then:
+        resp.statusCode() == 200
+        json.isbn == '9780451524935'
+        json.title == '1984'
+    }
+
+    void "PUT /book/:id updates an existing book"() {
+        given:
+        Book.withNewTransaction {
+            if (!Book.findByIsbn('9780141439518')) {
+                new Book(title: 'Pride', isbn: '9780141439518', pageCount: 280).save(failOnError: true)
+            }
+        }
+        Long bookId = Book.withNewTransaction { Book.findByIsbn('9780141439518').id }
+        String updateBody = JsonOutput.toJson([title: 'Pride and Prejudice', isbn: '9780141439518', pageCount: 432])
+
+        when:
+        HttpResponse<String> resp = client.send(
+                HttpRequest.newBuilder(uri("/books/${bookId}"))
+                        .header('Content-Type', 'application/json')
+                        .header('Accept', 'application/json')
+                        .PUT(HttpRequest.BodyPublishers.ofString(updateBody)).build(),
+                HttpResponse.BodyHandlers.ofString())
+
+        then:
+        resp.statusCode() == 200
+        Book.withNewTransaction {
+            Book.findByIsbn('9780141439518').title == 'Pride and Prejudice'
+        }
+    }
+
+    void "DELETE /book/:id removes a book"() {
+        given:
+        Long bookId = Book.withNewTransaction {
+            def b = new Book(title: 'Temp', isbn: '9780000000999', pageCount: 50).save(failOnError: true)
+            b.id
+        }
+
+        when:
+        HttpResponse<String> resp = client.send(
+                HttpRequest.newBuilder(uri("/books/${bookId}"))
+                        .header('Accept', 'application/json')
+                        .DELETE().build(),
+                HttpResponse.BodyHandlers.ofString())
+
+        then:
+        resp.statusCode() == 204
+        Book.withNewTransaction { Book.get(bookId) == null }
+    }
+
+    void "GET /book/:id returns 404 for a nonexistent id"() {
+        when:
+        HttpResponse<String> resp = client.send(
+                HttpRequest.newBuilder(uri('/books/99999.json')).GET().build(),
+                HttpResponse.BodyHandlers.ofString())
+
+        then:
+        resp.statusCode() == 404
+    }
 }

--- a/guides/grails-multi-module/v8/snippets/webapp-admin/src/integration-test/groovy/admin/AdminBookFunctionalSpec.groovy
+++ b/guides/grails-multi-module/v8/snippets/webapp-admin/src/integration-test/groovy/admin/AdminBookFunctionalSpec.groovy
@@ -28,7 +28,7 @@ class AdminBookFunctionalSpec extends Specification {
 
     private URI uri(String path) { URI.create("http://localhost:${serverPort}${path}") }
 
-    void "POST /book creates a shared-core Book and returns 201"() {
+    void "POST /books creates a shared-core Book and returns 201"() {
         given:
         String body = JsonOutput.toJson([title: 'Dune', isbn: '9780441013593', pageCount: 412])
 
@@ -45,7 +45,7 @@ class AdminBookFunctionalSpec extends Specification {
         Book.withNewTransaction { Book.findByIsbn('9780441013593')?.title == 'Dune' }
     }
 
-    void "GET /book lists the shared-core Books as JSON"() {
+    void "GET /books lists the shared-core Books as JSON"() {
         given:
         Book.withNewTransaction {
             if (!Book.findByIsbn('9780547928227')) {
@@ -64,7 +64,7 @@ class AdminBookFunctionalSpec extends Specification {
         json*.isbn.contains('9780547928227')
     }
 
-    void "POST /book with a malformed isbn returns 422"() {
+    void "POST /books with a malformed isbn returns 422"() {
         given:
         String body = JsonOutput.toJson([title: 'Bad', isbn: 'not-an-isbn'])
 
@@ -80,7 +80,7 @@ class AdminBookFunctionalSpec extends Specification {
         resp.statusCode() == 422
     }
 
-    void "GET /book/:id shows a single book as JSON"() {
+    void "GET /books/:id shows a single book as JSON"() {
         given:
         Book.withNewTransaction {
             if (!Book.findByIsbn('9780451524935')) {
@@ -102,7 +102,7 @@ class AdminBookFunctionalSpec extends Specification {
         json.title == '1984'
     }
 
-    void "PUT /book/:id updates an existing book"() {
+    void "PUT /books/:id updates an existing book"() {
         given:
         Book.withNewTransaction {
             if (!Book.findByIsbn('9780141439518')) {
@@ -127,7 +127,7 @@ class AdminBookFunctionalSpec extends Specification {
         }
     }
 
-    void "DELETE /book/:id removes a book"() {
+    void "DELETE /books/:id removes a book"() {
         given:
         Long bookId = Book.withNewTransaction {
             def b = new Book(title: 'Temp', isbn: '9780000000999', pageCount: 50).save(failOnError: true)
@@ -146,7 +146,7 @@ class AdminBookFunctionalSpec extends Specification {
         Book.withNewTransaction { Book.get(bookId) == null }
     }
 
-    void "GET /book/:id returns 404 for a nonexistent id"() {
+    void "GET /books/:id returns 404 for a nonexistent id"() {
         when:
         HttpResponse<String> resp = client.send(
                 HttpRequest.newBuilder(uri('/books/99999.json')).GET().build(),

--- a/guides/grails-multi-module/v8/snippets/webapp-customer/src/integration-test/groovy/customer/CatalogFunctionalSpec.groovy
+++ b/guides/grails-multi-module/v8/snippets/webapp-customer/src/integration-test/groovy/customer/CatalogFunctionalSpec.groovy
@@ -48,4 +48,36 @@ class CatalogFunctionalSpec extends Specification {
         json*.isbn.contains('9780547928227')
         json*.isbn.contains('9780441013593')
     }
+
+    void "GET /catalog/show/:id returns a single book as JSON"() {
+        given:
+        Long bookId = Book.withNewTransaction {
+            Book.findByIsbn('9780547928227').id
+        }
+
+        when:
+        HttpResponse<String> resp = client.send(
+                HttpRequest.newBuilder(URI.create("http://localhost:${serverPort}/catalog/show/${bookId}.json"))
+                        .header('Accept', 'application/json')
+                        .GET().build(),
+                HttpResponse.BodyHandlers.ofString())
+        def json = new JsonSlurper().parseText(resp.body())
+
+        then:
+        resp.statusCode() == 200
+        json.title == 'The Hobbit'
+        json.isbn == '9780547928227'
+    }
+
+    void "GET /catalog/show/:id returns 404 for nonexistent book"() {
+        when:
+        HttpResponse<String> resp = client.send(
+                HttpRequest.newBuilder(URI.create("http://localhost:${serverPort}/catalog/show/99999.json"))
+                        .header('Accept', 'application/json')
+                        .GET().build(),
+                HttpResponse.BodyHandlers.ofString())
+
+        then:
+        resp.statusCode() == 404
+    }
 }

--- a/guides/grails-rest-library/v8/snippets/grails-app/controllers/example/UrlMappings.groovy
+++ b/guides/grails-rest-library/v8/snippets/grails-app/controllers/example/UrlMappings.groovy
@@ -11,7 +11,7 @@ class UrlMappings {
         }
         '/v1/authors'(resources: 'author')
 
-        '/'(view: '/index')
+        '/'(controller: 'application', action: 'index')
 
         '500'(view: '/error')
         '404'(view: '/notFound')

--- a/guides/grails-rest-library/v8/snippets/src/integration-test/groovy/example/BookFunctionalSpec.groovy
+++ b/guides/grails-rest-library/v8/snippets/src/integration-test/groovy/example/BookFunctionalSpec.groovy
@@ -124,4 +124,196 @@ class BookFunctionalSpec extends Specification {
         json.total >= 1
         json.items.any { it.name == 'Functional Author' }
     }
+
+    // -------------------------------------------------------------------------
+    // Show (GET /v1/books/{id})
+    // -------------------------------------------------------------------------
+
+    void "GET /v1/books/{id} returns a single book"() {
+        given:
+        Long bookId = Book.withNewTransaction {
+            Book.findByIsbn('9781111111113').id
+        }
+
+        when:
+        HttpResponse<String> resp = getJson("/v1/books/${bookId}")
+        Map json = new JsonSlurper().parseText(resp.body()) as Map
+
+        then:
+        resp.statusCode() == 200
+        json.title == 'Seeded One'
+        json.isbn == '9781111111113'
+        json.pageCount == 100
+        json.author.name == 'Functional Author'
+        json._links.self.href.contains("id=${bookId}")
+    }
+
+    void "GET /v1/books/{id} returns 404 for non-existent book"() {
+        when:
+        HttpResponse<String> resp = getJson('/v1/books/999999')
+
+        then:
+        resp.statusCode() == 404
+    }
+
+    // -------------------------------------------------------------------------
+    // Save (POST /v1/books)
+    // -------------------------------------------------------------------------
+
+    void "POST /v1/books creates a new book"() {
+        given:
+        String body = JsonOutput.toJson([
+            title: 'Functional Created', isbn: '9780000000003', pageCount: 250,
+            author: [id: authorId]
+        ])
+
+        when:
+        HttpResponse<String> resp = postJson('/v1/books', body)
+        Map json = new JsonSlurper().parseText(resp.body()) as Map
+
+        then:
+        resp.statusCode() == 201
+        json.title == 'Functional Created'
+        json.isbn == '9780000000003'
+
+        cleanup:
+        Book.withNewTransaction { Book.findByIsbn('9780000000003')?.delete(flush: true) }
+    }
+
+    void "POST /v1/books returns 422 when validation fails"() {
+        given:
+        String body = JsonOutput.toJson([
+            title: '', isbn: 'bad-isbn', author: [id: authorId]
+        ])
+
+        when:
+        HttpResponse<String> resp = postJson('/v1/books', body)
+        Map json = new JsonSlurper().parseText(resp.body()) as Map
+
+        then:
+        resp.statusCode() == 422
+        json.errors.any { it.field == 'title' }
+        json.errors.any { it.field == 'isbn' }
+    }
+
+    // -------------------------------------------------------------------------
+    // Update (PUT /v1/books/{id})
+    // -------------------------------------------------------------------------
+
+    private HttpResponse<String> putJson(String path, String body) {
+        client.send(HttpRequest.newBuilder(uri(path))
+                .header('Content-Type', 'application/json')
+                .PUT(HttpRequest.BodyPublishers.ofString(body)).build(),
+                HttpResponse.BodyHandlers.ofString())
+    }
+
+    void "PUT /v1/books/{id} updates an existing book"() {
+        given:
+        Long bookId = Book.withNewTransaction { Book.findByIsbn('9782222222226').id }
+        String body = JsonOutput.toJson([title: 'Updated Title', pageCount: 999])
+
+        when:
+        HttpResponse<String> resp = putJson("/v1/books/${bookId}", body)
+        Map json = new JsonSlurper().parseText(resp.body()) as Map
+
+        then:
+        resp.statusCode() == 200
+        json.title == 'Updated Title'
+        json.pageCount == 999
+
+        cleanup:
+        Book.withNewTransaction {
+            Book b = Book.findByIsbn('9782222222226')
+            if (b) {
+                b.title = 'Seeded Two'
+                b.pageCount = 200
+                b.save(flush: true, failOnError: true)
+            }
+        }
+    }
+
+    void "PUT /v1/books/{id} returns 422 when validation fails"() {
+        given:
+        Long bookId = Book.withNewTransaction { Book.findByIsbn('9781111111113').id }
+        String body = JsonOutput.toJson([title: ''])
+
+        when:
+        HttpResponse<String> resp = putJson("/v1/books/${bookId}", body)
+
+        then:
+        resp.statusCode() == 422
+    }
+
+    void "PUT /v1/books/{id} returns 404 for non-existent book"() {
+        when:
+        HttpResponse<String> resp = putJson('/v1/books/999999', JsonOutput.toJson([title: 'Nope']))
+
+        then:
+        resp.statusCode() == 404
+    }
+
+    // -------------------------------------------------------------------------
+    // Delete (DELETE /v1/books/{id})
+    // -------------------------------------------------------------------------
+
+    private HttpResponse<String> deleteResource(String path) {
+        client.send(HttpRequest.newBuilder(uri(path)).DELETE().build(),
+                HttpResponse.BodyHandlers.ofString())
+    }
+
+    void "DELETE /v1/books/{id} deletes a book"() {
+        given: 'a disposable book not used by other tests'
+        Long disposableId = Book.withNewTransaction {
+            new Book(author: Author.findByName('Functional Author'),
+                     title: 'Delete Me Book', isbn: '9789999999997', pageCount: 1)
+                .save(flush: true, failOnError: true).id
+        }
+
+        when:
+        HttpResponse<String> resp = deleteResource("/v1/books/${disposableId}")
+
+        then:
+        resp.statusCode() == 204
+        Book.withNewTransaction { Book.get(disposableId) == null }
+    }
+
+    void "DELETE /v1/books/{id} returns 404 for non-existent book"() {
+        when:
+        HttpResponse<String> resp = deleteResource('/v1/books/999999')
+
+        then:
+        resp.statusCode() == 404
+    }
+
+    // -------------------------------------------------------------------------
+    // Author filter on GET /v1/books
+    // -------------------------------------------------------------------------
+
+    void "GET /v1/books?author= filters by author"() {
+        given:
+        Long firstAuthorId = Book.withNewTransaction { Author.list().first().id }
+
+        when:
+        HttpResponse<String> resp = getJson("/v1/books?author=${firstAuthorId}")
+        Map json = new JsonSlurper().parseText(resp.body()) as Map
+
+        then:
+        resp.statusCode() == 200
+        json.items.size() > 0
+        json.items.every { it.author.id == firstAuthorId }
+    }
+
+    // -------------------------------------------------------------------------
+    // Negative offset clamping
+    // -------------------------------------------------------------------------
+
+    void "GET /v1/books?offset= clamps negative offset to 0"() {
+        when:
+        HttpResponse<String> resp = getJson('/v1/books?offset=-5')
+        Map json = new JsonSlurper().parseText(resp.body()) as Map
+
+        then:
+        resp.statusCode() == 200
+        json.page == 0
+    }
 }

--- a/guides/grails-rest-library/v8/snippets/src/integration-test/groovy/example/BookFunctionalSpec.groovy
+++ b/guides/grails-rest-library/v8/snippets/src/integration-test/groovy/example/BookFunctionalSpec.groovy
@@ -290,17 +290,24 @@ class BookFunctionalSpec extends Specification {
     // -------------------------------------------------------------------------
 
     void "GET /v1/books?author= filters by author"() {
-        given:
-        Long firstAuthorId = Book.withNewTransaction { Author.list().first().id }
+        given: 'two authors, each owning a distinct book, so the filter has something to exclude'
+        Long targetAuthorId = Book.withNewTransaction {
+            Author target = new Author(name: 'Filter Target Author').save(failOnError: true)
+            Author other = new Author(name: 'Filter Other Author').save(failOnError: true)
+            new Book(author: target, title: 'Target Book', isbn: '9784444444443', pageCount: 100).save(failOnError: true)
+            new Book(author: other, title: 'Excluded Book', isbn: '9785555555556', pageCount: 100).save(failOnError: true)
+            target.id
+        }
 
         when:
-        HttpResponse<String> resp = getJson("/v1/books?author=${firstAuthorId}")
+        HttpResponse<String> resp = getJson("/v1/books?author=${targetAuthorId}")
         Map json = new JsonSlurper().parseText(resp.body()) as Map
 
-        then:
+        then: 'only the target author\'s books come back; the other author\'s book is excluded'
         resp.statusCode() == 200
         json.items.size() > 0
-        json.items.every { it.author.id == firstAuthorId }
+        json.items.every { it.author.id == targetAuthorId }
+        json.items.every { it.isbn != '9785555555556' }
     }
 
     // -------------------------------------------------------------------------

--- a/guides/grails-spock-test-tour/v8/snippets/grails-app/controllers/example/BookController.groovy
+++ b/guides/grails-spock-test-tour/v8/snippets/grails-app/controllers/example/BookController.groovy
@@ -12,9 +12,10 @@ class BookController extends RestfulController<Book> {
 
     // Minimal override so the show action is explicitly registered as a
     // controller action (sibling project debugging revealed that inherited
-    // RestfulController actions can be invisible to the URL-mapping layer).
+    // RestfulController actions can be invisible to the URL-mapping layer);
+    // it delegates to RestfulController.show() to stay framework-aligned.
     def show() {
-        respond queryForResource(params.get('id'))
+        super.show()
     }
 
     // Override index so the HTML format renders the GSP table view (through the

--- a/guides/grails-spock-test-tour/v8/snippets/grails-app/controllers/example/BookController.groovy
+++ b/guides/grails-spock-test-tour/v8/snippets/grails-app/controllers/example/BookController.groovy
@@ -10,6 +10,13 @@ class BookController extends RestfulController<Book> {
     BookService bookService
     BookController() { super(Book) }
 
+    // Minimal override so the show action is explicitly registered as a
+    // controller action (sibling project debugging revealed that inherited
+    // RestfulController actions can be invisible to the URL-mapping layer).
+    def show() {
+        respond queryForResource(params.get('id'))
+    }
+
     // Override index so the HTML format renders the GSP table view (through the
     // sitemesh layout) while JSON clients still get the REST collection.
     def index(Integer max) {
@@ -20,4 +27,5 @@ class BookController extends RestfulController<Book> {
             json { respond books, [model: [bookCount: countResources()]] }
         }
     }
+
 }

--- a/guides/grails-spock-test-tour/v8/snippets/src/integration-test/groovy/example/BookFunctionalSpec.groovy
+++ b/guides/grails-spock-test-tour/v8/snippets/src/integration-test/groovy/example/BookFunctionalSpec.groovy
@@ -38,4 +38,5 @@ class BookFunctionalSpec extends ContainerGebSpec {
         $('table tbody tr').size() > 0
         $('table tbody').text().contains('The Hobbit')
     }
+
 }

--- a/guides/grails-spock-test-tour/v8/snippets/src/test/groovy/example/BookControllerSpec.groovy
+++ b/guides/grails-spock-test-tour/v8/snippets/src/test/groovy/example/BookControllerSpec.groovy
@@ -54,21 +54,20 @@ class BookControllerSpec extends Specification
         response.status == HttpStatus.UNPROCESSABLE_ENTITY.value()
     }
 
-    void "GET /books returns the book list as JSON"() {
+    void "index returns the persisted books in its model"() {
         given:
         new Book(title: 'First', isbn: '9780547928227', pageCount: 100)
             .save(flush: true, failOnError: true)
         new Book(title: 'Second', isbn: '9780547928228', pageCount: 200)
             .save(flush: true, failOnError: true)
 
-        when:
+        when: 'the index action builds its model (HTML format returns the model map)'
         request.method = 'GET'
-        request.format = 'json'
-        controller.index(10)
+        Map model = controller.index(10)
 
         then:
-        response.status == HttpStatus.OK.value()
-        response.contentAsString != null
+        model.bookCount == 2
+        model.bookList*.title.containsAll(['First', 'Second'])
     }
 
     void "POST /books with valid data saves and returns 201"() {

--- a/guides/grails-spock-test-tour/v8/snippets/src/test/groovy/example/BookControllerSpec.groovy
+++ b/guides/grails-spock-test-tour/v8/snippets/src/test/groovy/example/BookControllerSpec.groovy
@@ -53,4 +53,107 @@ class BookControllerSpec extends Specification
         then:
         response.status == HttpStatus.UNPROCESSABLE_ENTITY.value()
     }
+
+    void "GET /books returns the book list as JSON"() {
+        given:
+        new Book(title: 'First', isbn: '9780547928227', pageCount: 100)
+            .save(flush: true, failOnError: true)
+        new Book(title: 'Second', isbn: '9780547928228', pageCount: 200)
+            .save(flush: true, failOnError: true)
+
+        when:
+        request.method = 'GET'
+        request.format = 'json'
+        controller.index(10)
+
+        then:
+        response.status == HttpStatus.OK.value()
+        response.contentAsString != null
+    }
+
+    void "POST /books with valid data saves and returns 201"() {
+        given:
+        request.method = 'POST'
+        request.json = [title: 'Valid Book', isbn: '9780547928228', pageCount: 150]
+
+        when:
+        controller.save()
+
+        then:
+        response.status == HttpStatus.CREATED.value()
+        response.json.title == 'Valid Book'
+        response.json.isbn  == '9780547928228'
+    }
+
+    void "GET /books/create returns a new transient instance"() {
+        when:
+        request.method = 'GET'
+        request.format = 'json'
+        controller.create()
+
+        then:
+        response.status == HttpStatus.OK.value()
+    }
+
+    void "GET /books/{id}/edit returns the book for editing"() {
+        given:
+        Book b = new Book(title: 'Editable', isbn: '9780547928228', pageCount: 100)
+            .save(flush: true, failOnError: true)
+
+        when:
+        request.method = 'GET'
+        request.format = 'json'
+        params.id = b.id
+        controller.edit()
+
+        then:
+        response.status == HttpStatus.OK.value()
+        response.json.title == 'Editable'
+    }
+
+    void "PUT /books/{id} updates the book"() {
+        given:
+        Book b = new Book(title: 'Original', isbn: '9780547928228', pageCount: 100)
+            .save(flush: true, failOnError: true)
+
+        when:
+        request.method = 'PUT'
+        request.json = [title: 'Updated']
+        params.id = b.id
+        controller.update()
+
+        then:
+        response.status == HttpStatus.OK.value()
+        response.json.title == 'Updated'
+    }
+
+    void "PUT /books/{id} with invalid data returns 422"() {
+        given:
+        Book b = new Book(title: 'Original', isbn: '9780547928229', pageCount: 100)
+            .save(flush: true, failOnError: true)
+
+        when:
+        request.method = 'PUT'
+        request.json = [title: '']
+        params.id = b.id
+        controller.update()
+
+        then:
+        response.status == HttpStatus.UNPROCESSABLE_ENTITY.value()
+    }
+
+    void "DELETE /books/{id} deletes the book"() {
+        given:
+        Book b = new Book(title: 'Deletable', isbn: '9780547928228', pageCount: 100)
+            .save(flush: true, failOnError: true)
+
+        when:
+        request.method = 'DELETE'
+        params.id = b.id
+        controller.delete()
+
+        then:
+        response.status == HttpStatus.NO_CONTENT.value()
+        Book.get(b.id) == null
+    }
 }

--- a/guides/grails-spock-test-tour/v8/snippets/src/test/groovy/example/BookServiceSpec.groovy
+++ b/guides/grails-spock-test-tour/v8/snippets/src/test/groovy/example/BookServiceSpec.groovy
@@ -43,4 +43,53 @@ class BookServiceSpec extends Specification
         expect:
         service.findByIsbn('9999999999999') == null
     }
+
+    void "get returns the book when it exists"() {
+        given: 'the isbn from the setup fixture'
+        Book b = Book.findByIsbn('9780000000001')
+
+        expect:
+        service.get(b.id)?.title == 'Short Story'
+    }
+
+    void "get returns null when the id does not exist"() {
+        expect:
+        service.get(99999L) == null
+    }
+
+    void "save persists a book and returns it with an id"() {
+        when:
+        Book saved = service.save(new Book(
+            title: 'New Book', isbn: '9780000000005', pageCount: 200))
+
+        then:
+        saved.id != null
+        saved.title == 'New Book'
+
+        and: 'it is visible to a subsequent query'
+        service.countByPageCountGreaterThanEquals(0) == 5
+    }
+
+    void "save rejects a duplicate isbn with ValidationException"() {
+        given:
+        service.save(new Book(title: 'Original', isbn: '9780000000005', pageCount: 100))
+        Book.withSession { it.flush() }
+
+        when:
+        service.save(new Book(title: 'Duplicate', isbn: '9780000000005', pageCount: 200))
+
+        then:
+        def ex = thrown(grails.validation.ValidationException)
+        ex.message.contains('unique')
+    }
+
+    void "list returns all books when called without constraints"() {
+        expect:
+        service.list([:]).size() == 4
+    }
+
+    void "list respects the max parameter"() {
+        expect:
+        service.list([max: 2]).size() == 2
+    }
 }

--- a/guides/grails-tailwindcss/v8/snippets/src/integration-test/groovy/example/TailwindFunctionalSpec.groovy
+++ b/guides/grails-tailwindcss/v8/snippets/src/integration-test/groovy/example/TailwindFunctionalSpec.groovy
@@ -53,6 +53,23 @@ class TailwindFunctionalSpec extends ContainerGebSpec {
         bg && bg != 'rgba(0, 0, 0, 0)' && bg != 'transparent'
     }
 
+    void 'the 404 page renders when navigating to an unknown path'() {
+        when:
+        go '/nonexistent-route'
+
+        then:
+        title == 'Page Not Found'
+        $('h1').text().contains('Page Not Found (404)')
+    }
+
+    void 'the 404 page shows the requested path'() {
+        when:
+        go '/some/missing/page'
+
+        then:
+        $('body').text().contains('/some/missing/page')
+    }
+
     void 'the dark-mode toggle adds the dark class and persists the choice'() {
         given:
         go '/'

--- a/guides/grails-vite-spa/v8/snippets/backend/src/integration-test/groovy/example/ApiFunctionalSpec.groovy
+++ b/guides/grails-vite-spa/v8/snippets/backend/src/integration-test/groovy/example/ApiFunctionalSpec.groovy
@@ -127,4 +127,164 @@ class ApiFunctionalSpec extends Specification {
         then: 'the static bundle is served from the same origin'
         asset.statusCode() == 200
     }
+
+    // ---------------------------------------------------------------------------
+    // Missing CRUD endpoint coverage
+    // ---------------------------------------------------------------------------
+
+    void "GET /api/books/:id returns a single book"() {
+        given:
+        Book.withNewTransaction {
+            if (!Book.findByIsbn('9780553380954')) {
+                new Book(title: 'Foundation', author: 'Isaac Asimov', isbn: '9780553380954').save(failOnError: true)
+            }
+        }
+        Long id = Book.withNewTransaction { Book.findByIsbn('9780553380954').id }
+
+        when:
+        HttpResponse<String> resp = client.send(
+                HttpRequest.newBuilder(uri("/api/books/${id}")).GET().build(),
+                HttpResponse.BodyHandlers.ofString())
+        Map json = new JsonSlurper().parseText(resp.body()) as Map
+
+        then:
+        resp.statusCode() == 200
+        json.title == 'Foundation'
+        json.author == 'Isaac Asimov'
+        json.isbn == '9780553380954'
+    }
+
+    void "GET /api/books/:id returns 404 for a non-existent book"() {
+        when:
+        HttpResponse<String> resp = client.send(
+                HttpRequest.newBuilder(uri('/api/books/999999')).GET().build(),
+                HttpResponse.BodyHandlers.ofString())
+
+        then:
+        resp.statusCode() == 404
+    }
+
+    void "PUT /api/books/:id updates an existing book"() {
+        given:
+        Book.withNewTransaction {
+            if (!Book.findByIsbn('9780345391803')) {
+                new Book(title: 'Hitchhiker', author: 'Douglas Adams', isbn: '9780345391803').save(failOnError: true)
+            }
+        }
+        Long id = Book.withNewTransaction { Book.findByIsbn('9780345391803').id }
+        String body = JsonOutput.toJson([title: 'Hitchhikers Guide', author: 'Douglas Adams', isbn: '9780345391803'])
+
+        when:
+        HttpResponse<String> resp = client.send(
+                HttpRequest.newBuilder(uri("/api/books/${id}"))
+                        .header('Content-Type', 'application/json')
+                        .PUT(HttpRequest.BodyPublishers.ofString(body)).build(),
+                HttpResponse.BodyHandlers.ofString())
+
+        then:
+        resp.statusCode() == 200
+        Book.withNewTransaction {
+            Book.findByIsbn('9780345391803').title == 'Hitchhikers Guide'
+        }
+    }
+
+    void "PUT /api/books/:id with invalid data returns 422"() {
+        given:
+        Book.withNewTransaction {
+            if (!Book.findByIsbn('9780451524935')) {
+                new Book(title: '1984', author: 'George Orwell', isbn: '9780451524935').save(failOnError: true)
+            }
+        }
+        Long id = Book.withNewTransaction { Book.findByIsbn('9780451524935').id }
+        String body = JsonOutput.toJson([title: '', author: '', isbn: '9780451524935'])
+
+        when:
+        HttpResponse<String> resp = client.send(
+                HttpRequest.newBuilder(uri("/api/books/${id}"))
+                        .header('Content-Type', 'application/json')
+                        .PUT(HttpRequest.BodyPublishers.ofString(body)).build(),
+                HttpResponse.BodyHandlers.ofString())
+
+        then:
+        resp.statusCode() == 422
+    }
+
+    void "PUT /api/books/:id for non-existent returns 404"() {
+        given:
+        String body = JsonOutput.toJson([title: 'Ghost', author: 'Nobody', isbn: '9780000000000'])
+
+        when:
+        HttpResponse<String> resp = client.send(
+                HttpRequest.newBuilder(uri('/api/books/999999'))
+                        .header('Content-Type', 'application/json')
+                        .PUT(HttpRequest.BodyPublishers.ofString(body)).build(),
+                HttpResponse.BodyHandlers.ofString())
+
+        then:
+        resp.statusCode() == 404
+    }
+
+    void "DELETE /api/books/:id deletes a book and returns 204"() {
+        given:
+        Book.withNewTransaction {
+            if (!Book.findByIsbn('9780439023481')) {
+                new Book(title: 'Mockingjay', author: 'Suzanne Collins', isbn: '9780439023481').save(failOnError: true)
+            }
+        }
+        Long id = Book.withNewTransaction { Book.findByIsbn('9780439023481').id }
+
+        when:
+        HttpResponse<Void> resp = client.send(
+                HttpRequest.newBuilder(uri("/api/books/${id}")).DELETE().build(),
+                HttpResponse.BodyHandlers.discarding())
+
+        then:
+        resp.statusCode() == 204
+        Book.withNewTransaction { Book.findByIsbn('9780439023481') == null }
+    }
+
+    void "DELETE /api/books/:id for non-existent returns 404"() {
+        when:
+        HttpResponse<Void> resp = client.send(
+                HttpRequest.newBuilder(uri('/api/books/999999')).DELETE().build(),
+                HttpResponse.BodyHandlers.discarding())
+
+        then:
+        resp.statusCode() == 404
+    }
+
+    void "POST /api/books with blank title returns 422"() {
+        given:
+        String body = JsonOutput.toJson([title: '', author: 'Someone', isbn: '9780140449266'])
+
+        when:
+        HttpResponse<String> resp = client.send(
+                HttpRequest.newBuilder(uri('/api/books'))
+                        .header('Content-Type', 'application/json')
+                        .POST(HttpRequest.BodyPublishers.ofString(body)).build(),
+                HttpResponse.BodyHandlers.ofString())
+
+        then:
+        resp.statusCode() == 422
+    }
+
+    void "GET /assets with path traversal returns 400"() {
+        when:
+        HttpResponse<String> resp = client.send(
+                HttpRequest.newBuilder(uri('/assets/../../etc/passwd')).GET().build(),
+                HttpResponse.BodyHandlers.ofString())
+
+        then:
+        resp.statusCode() == 400
+    }
+
+    void "GET /assets for a non-existent file returns 404"() {
+        when:
+        HttpResponse<String> resp = client.send(
+                HttpRequest.newBuilder(uri('/assets/nonexistent-bundle.js')).GET().build(),
+                HttpResponse.BodyHandlers.ofString())
+
+        then:
+        resp.statusCode() == 404
+    }
 }

--- a/guides/grails-vite-spa/v8/snippets/backend/src/test/groovy/example/BookControllerSpec.groovy
+++ b/guides/grails-vite-spa/v8/snippets/backend/src/test/groovy/example/BookControllerSpec.groovy
@@ -6,9 +6,9 @@ import spock.lang.Specification
 
 /**
  * Controller unit test for the page-size clamp the overridden
- * listAllResources applies. It reads params.int('max', 25), so the spec
- * drives it through the controller's GrailsParameterMap (a plain Map has
- * no int() accessor). No Spring context boots.
+ * listAllResources applies and other controller behaviours that
+ * do not require GSON view rendering (which is covered by the
+ * functional HTTP tests in ApiFunctionalSpec).
  */
 class BookControllerSpec extends Specification
         implements ControllerUnitTest<BookController>, DataTest {


### PR DESCRIPTION
## Summary

Re-vendors the v8 guide snippets to match the now-CI-green upstream sample-app
PRs, so the published guide code matches what actually compiles, boots, and
passes tests on a clean runner. Every functional spec uses the canonical
`ContainerGebSpec` (Testcontainers) or `@Integration` + `HttpClient` - no
`webdriver-binaries` anywhere.

## Guides re-vendored (9)

| Guide | Upstream PR | What changed |
|---|---|---|
| grails-fields-custom-widgets-and-wrappers | #1 | domain-agnostic `f:table` + full per-action Geb coverage |
| grails-rest-library | #11 | root URL-mapping fix + expanded REST functional spec |
| grails-spock-test-tour | #1 | `BookController` show fix + controller/service/functional specs |
| grails-htmx | #2 | `TaskController` + integration/functional specs |
| grails-tailwindcss | #1 | functional spec |
| grails-vite-spa | #1 | API functional + controller unit spec |
| grails-docker-bootbuildimage | #7 | Testcontainers BOM platform line |
| grails-github-actions-cicd | #2 | home / integration / message specs |
| grails-multi-module | #9 | webapp-admin + webapp-customer functional specs |

Snippets are byte-identical to the upstream `complete/` (and `initial/`) trees on each PR's `grails8` branch. All nine guides render clean (`renderGuide_* BUILD SUCCESSFUL`).

The `grails-transactional-events` v8 guide is handled in its own static-site PR (#509), synced to grails-guides/grails-transactional-events#1.
