### PR TITLE
Add Grails version filter to the guides listing page

### DIFF
--- a/assets/javascripts/search.js
+++ b/assets/javascripts/search.js
@@ -9,6 +9,7 @@ const elementsClassNames = [
     'training',
     'latest-guides',
     'guide-group',
+    'versions-by-grails',
     'tags-by-topic',
     'guides-suggestion',
 ]

--- a/assets/stylesheets/screen.css
+++ b/assets/stylesheets/screen.css
@@ -992,6 +992,38 @@ body.grails3-plugins .tags-by-topic ul {
 .tags-by-topic li.tag49{ font-size: 24px; background-color: #feb672;}
 .tags-by-topic li.tag50{ font-size: 24px; background-color: #feb672;}
 
+.versions-by-grails ul {
+	margin: 40px 0 20px 0;
+	padding: 0;
+	overflow: auto;
+}
+body.grails3-plugins .versions-by-grails ul {
+	padding-left: 20px;
+}
+.versions-by-grails li {
+	list-style-type: none;
+	background-color: #255AA8;
+	float: left;
+	margin-right: 6px;
+	margin-bottom: 6px;
+	height: 20px;
+	font-size: 16px;
+	line-height: 14px;
+	vertical-align: middle;
+	padding: 7px 12px 5px;
+	border-radius: 3px;
+}
+.versions-by-grails li:hover {
+	background-color: #1d4684;
+}
+.versions-by-grails li a {
+	display: block;
+	text-decoration: none;
+	color: #ffffff;
+	text-transform: uppercase;
+	white-space: nowrap;
+}
+
 footer {
 	clear: both;
 	background-color: #ffffff;

--- a/buildSrc/src/main/groovy/website/gradle/tasks/GuidesTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/GuidesTask.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
@@ -85,6 +86,16 @@ abstract class GuidesTask extends GrailsWebsiteTask {
     @OutputDirectory
     abstract DirectoryProperty getOutputDir()
 
+    /**
+     * Shared chrome partials ({@code templates/partials/}) wired in at
+     * configuration time. Captured as a task input rather than read through
+     * {@code project} at execution time so the task is compatible with the
+     * configuration cache, mirroring {@code RenderSiteTask.getPartialsDir()}.
+     */
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
+    abstract DirectoryProperty getPartialsDir()
+
     static TaskProvider<GuidesTask> register(
             Project project,
             GrailsWebsiteExtension siteExt,
@@ -99,6 +110,7 @@ abstract class GuidesTask extends GrailsWebsiteTask {
             it.releases.set(siteExt.releases)
             it.title.set(siteExt.title)
             it.url.set(siteExt.url)
+            it.partialsDir.set(siteExt.partialsDir)
             it.guidesYml.set(project.layout.projectDirectory.file('conf/guides.yml'))
         }
     }
@@ -131,9 +143,7 @@ abstract class GuidesTask extends GrailsWebsiteTask {
         // Resolve [%PARTIAL:<name>] tokens against the same partial bundle
         // RenderSiteTask uses, so guides/index.html, tag, and category pages
         // share the main-site chrome.
-        File partialsRoot = project.rootProject.layout.projectDirectory
-                .dir('templates/partials').asFile
-        File partialsArg = partialsRoot.isDirectory() ? partialsRoot : null
+        File partialsArg = partialsDir.isPresent() ? partialsDir.get().asFile : null
         RenderSiteTask.renderPages(meta, [page], distDir, templateText, partialsArg)
         RenderSiteTask.renderPages(
                 meta,

--- a/buildSrc/src/main/groovy/website/gradle/tasks/GuidesTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/GuidesTask.groovy
@@ -159,6 +159,13 @@ abstract class GuidesTask extends GrailsWebsiteTask {
                 templateText,
                 partialsArg
         )
+        RenderSiteTask.renderPages(
+                meta,
+                parseVersionsPages(tempDir),
+                new File(distDir, 'versions').tap { it.mkdirs() },
+                templateText,
+                partialsArg
+        )
     }
 
     static List<Page> parseCategoryPages(File pages) {
@@ -173,6 +180,14 @@ abstract class GuidesTask extends GrailsWebsiteTask {
         List<Page> listOfPages = []
         new File(pages, 'tags').eachFile { tagFile ->
             listOfPages << pageWithFile(tagFile)
+        }
+        listOfPages
+    }
+
+    static List<Page> parseVersionsPages(File pages) {
+        List<Page> listOfPages = []
+        new File(pages, 'versions').eachFile { versionFile ->
+            listOfPages << pageWithFile(versionFile)
         }
         listOfPages
     }
@@ -212,6 +227,15 @@ abstract class GuidesTask extends GrailsWebsiteTask {
             new File(categoriesDir, slug).setText(
                     "---\ntitle: Guides at category $category.name | Grails Framework\nbody: guides\n---\n" +
                             GuidesPage.mainContent(guides, tags, category, null),
+                    'UTF-8'
+            )
+        }
+        def versionsDir = new File(pages, 'versions').tap { it.mkdirs() }
+        for (def version : GuidesPage.availableVersions(guides)) {
+            def slug = "${version}.html"
+            new File(versionsDir, slug).setText(
+                    "---\ntitle: Guides for Grails $version | Grails Framework\nbody: guides\n---\n" +
+                            GuidesPage.mainContent(guides, tags, null, null, version),
                     'UTF-8'
             )
         }

--- a/buildSrc/src/main/groovy/website/model/guides/GuidesPage.groovy
+++ b/buildSrc/src/main/groovy/website/model/guides/GuidesPage.groovy
@@ -131,18 +131,21 @@ class GuidesPage {
             List<Guide> guides,
             Set<Tag> tags,
             Category category = null,
-            Tag tag = null
+            Tag tag = null,
+            String version = null
     ) {
         renderHtml {
             div(class: 'header-bar chalices-bg') {
                 div(class: 'content') {
-                    if (tag || category) {
+                    if (tag || category || version) {
                         h1 {
                             a(href: '[%url]/index.html', 'Guides')
                             if (tag) {
                                 mkp.yield(" → #$tag.title")
                             } else if(category) {
                                 mkp.yield(" → $category.name")
+                            } else if (version) {
+                                mkp.yield(" → Grails $version")
                             }
                         }
                     } else {
@@ -155,10 +158,10 @@ class GuidesPage {
                 omitNullAttributes = true
                 div(class: 'two-columns') {
                     div(class: 'column') {
-                        mkp.yieldUnescaped(rightColumn(tag, category, guides))
+                        mkp.yieldUnescaped(rightColumn(tag, category, version, guides))
                     }
                     div(class: 'column') {
-                        mkp.yieldUnescaped(leftColumn(tag, category, tags))
+                        mkp.yieldUnescaped(leftColumn(tag, category, tags, GuidesPage.availableVersions(guides), version))
                         if (tag) {
                             mkp.yieldUnescaped(guideGroupByTag(tag, guides))
                         } else if (category) {
@@ -169,7 +172,9 @@ class GuidesPage {
                                             false
                                     )
                             )
-                        } else {
+                        } else if (!version) {
+                            // Version pages render their list in the left column
+                            // (see rightColumn); this column only holds the clouds.
                             div(class: 'search-results') {
                                 mkp.yieldUnescaped('')
                             }
@@ -184,60 +189,60 @@ class GuidesPage {
                 // of high-level tracks for skimming by axis.
                 div(class: 'two-columns') {
                     div(class: 'column') {
-                        if (!(tag || category)) {
+                        if (!(tag || category || version)) {
                             mkp.yieldUnescaped(guideGroupByCategory(categories.apprentice, guides, true, 'margin-top: 0'))
                         }
                     }
                     div(class: 'column') {
-                        if (!(tag || category)) {
+                        if (!(tag || category || version)) {
                             mkp.yieldUnescaped(guideGroupByCategory(categories.advanced, guides, true, 'margin-top: 0'))
                         }
                     }
                 }
                 div(class: 'two-columns') {
                     div(class: 'column') {
-                        if (!(tag || category)) {
+                        if (!(tag || category || version)) {
                             mkp.yieldUnescaped(guideGroupByCategory(categories.weblayer, guides, true, 'margin-top: 0'))
                         }
                     }
                     div(class: 'column') {
-                        if (!(tag || category)) {
+                        if (!(tag || category || version)) {
                             mkp.yieldUnescaped(guideGroupByCategory(categories.devops, guides, true, 'margin-top: 0'))
                         }
                     }
                 }
                 div(class: 'two-columns') {
                     div(class: 'column') {
-                        if (!(tag || category)) {
+                        if (!(tag || category || version)) {
                             mkp.yieldUnescaped(guideGroupByCategory(categories.gorm, guides, true, 'margin-top: 0'))
                         }
                     }
                     div(class: 'column') {
-                        if (!(tag || category)) {
+                        if (!(tag || category || version)) {
                             mkp.yieldUnescaped(guideGroupByCategory(categories.testing, guides, true, 'margin-top: 0'))
                         }
                     }
                 }
                 div(class: 'two-columns') {
                     div(class: 'column') {
-                        if (!(tag || category)) {
+                        if (!(tag || category || version)) {
                             mkp.yieldUnescaped(guideGroupByCategory(categories.security, guides, true, 'margin-top: 0'))
                         }
                     }
                     div(class: 'column') {
-                        if (!(tag || category)) {
+                        if (!(tag || category || version)) {
                             mkp.yieldUnescaped(guideGroupByCategory(categories.spa, guides, true, 'margin-top: 0'))
                         }
                     }
                 }
                 div(class: 'two-columns') {
                     div(class: 'column') {
-                        if (!(tag || category)) {
+                        if (!(tag || category || version)) {
                             mkp.yieldUnescaped(guideGroupByCategory(categories.async, guides, true, 'margin-top: 0'))
                         }
                     }
                     div(class: 'column') {
-                        if (!(tag || category)) {
+                        if (!(tag || category || version)) {
                             mkp.yieldUnescaped(guideGroupByCategory(categories.cloud, guides, true, 'margin-top: 0'))
                         }
                     }
@@ -247,10 +252,14 @@ class GuidesPage {
     }
 
     @CompileDynamic
-    static String leftColumn(Tag tag, Category category, Set<Tag> tags) {
+    static String leftColumn(Tag tag, Category category, Set<Tag> tags, List<String> versions, String version = null) {
         renderHtml {
             div {
+                // Clouds stay visible on the index AND on version pages (so a
+                // reader on /versions/8 can jump to another version or a tag),
+                // but not on tag/category pages where they'd be redundant.
                 if (!(tag || category)) {
+                    mkp.yieldUnescaped(GuidesPage.versionCloud(versions))
                     mkp.yieldUnescaped(GuidesPage.tagCloud(tags))
                 }
             }
@@ -258,12 +267,16 @@ class GuidesPage {
     }
 
     @CompileDynamic
-    static String rightColumn(Tag tag, Category category, List<Guide> guides) {
+    static String rightColumn(Tag tag, Category category, String version, List<Guide> guides) {
         renderHtml {
             div {
-                mkp.yieldUnescaped(searchBox(tag, category))
-                if (!(tag || category)) {
-                    mkp.yieldUnescaped(GuidesPage.latestGuides(guides))
+                if (version) {
+                    mkp.yieldUnescaped(GuidesPage.guidesForVersion(version, guides))
+                } else {
+                    mkp.yieldUnescaped(searchBox(tag, category, version))
+                    if (!(tag || category)) {
+                        mkp.yieldUnescaped(GuidesPage.latestGuides(guides))
+                    }
                 }
             }
         }
@@ -329,8 +342,8 @@ class GuidesPage {
     }
 
     @CompileDynamic
-    static String searchBox(Tag tag, Category category) {
-        if (!(tag || category)) {
+    static String searchBox(Tag tag, Category category, String version = null) {
+        if (!(tag || category || version)) {
             renderHtml {
                 div(class: 'searchbox', style: 'margin-top: 50px !important') {
                     div(class: 'search', style: 'margin-bottom: 0px !important') {
@@ -389,5 +402,118 @@ class GuidesPage {
                 }
             }
         }
+    }
+
+    /**
+     * Renders the Grails-version cloud sidebar, sitting directly above the tag
+     * cloud (see {@link #tagCloud}). Where tags are a long, free-form taxonomy,
+     * the version axis is a short, closed set (the Grails major versions that
+     * actually carry guides), so it is the more useful first cut for a reader
+     * who only cares about "what can I read for the Grails I'm on". Each entry
+     * links to a statically generated {@code /guides/versions/<N>.html} page -
+     * exactly mirroring how tag entries link to {@code /guides/tags/<slug>.html}.
+     */
+    @CompileDynamic
+    static String versionCloud(List<String> versions) {
+        renderHtml {
+            div(class: 'versions-by-grails') {
+                h3(class: 'column-header', 'Guides by Grails Version')
+                ul(class: 'version-cloud') {
+                    versions.each { String v ->
+                        li {
+                            a(href: "$GUIDES_URL/versions/${v}.html", "Grails $v")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Renders every guide published for {@code version} using the same visual
+     * treatment as the {@link #latestGuides} list on the index (title, date +
+     * category, "Read More"), but with no {@code take()} cap - the version
+     * filter is meant to surface the full set, newest first. Each "Read More"
+     * link targets the matching version variant of the guide. This list lives
+     * in the left column with the version + tag clouds beside it on the right,
+     * mirroring the index layout.
+     */
+    @CompileDynamic
+    static String guidesForVersion(String version, List<Guide> guides) {
+        renderHtml {
+            div(class: 'latest-guides') {
+                h3(class: 'column-header', "Guides for Grails $version")
+                ul {
+                    guides
+                            .findAll { Guide guide -> GuidesPage.guideHasVersion(guide, version) }
+                            .sort { Guide a, Guide b ->
+                                Date da = a.publicationDate
+                                Date db = b.publicationDate
+                                if (da == db) {
+                                    return 0
+                                }
+                                if (da == null) {
+                                    return 1
+                                }
+                                if (db == null) {
+                                    return -1
+                                }
+                                db <=> da
+                            }
+                            .each { guide ->
+                                li {
+                                    b(guide.title)
+                                    span {
+                                        if (guide.publicationDate) {
+                                            mkp.yield(new SimpleDateFormat('MMM dd, yyyy').format(guide.publicationDate))
+                                            mkp.yield(' - ')
+                                        }
+                                        mkp.yield(guide.category)
+                                    }
+                                    a(
+                                            href: "$GUIDES_URL/${guide.name}/${version}/guide/index.html",
+                                            'Read More'
+                                    )
+                                }
+                            }
+                }
+            }
+        }
+    }
+
+    /**
+     * The distinct Grails major versions across all guides, newest first.
+     * A {@link SingleGuide} contributes its single {@code versionNumber}; a
+     * {@link GrailsVersionedGuide} contributes every key in
+     * {@code grailsMayorVersionTags}. Versions are guaranteed numeric major
+     * versions in {@code conf/guides.yml}, so they sort numerically descending.
+     */
+    static List<String> availableVersions(List<Guide> guides) {
+        Set<String> versions = [] as Set<String>
+        for (Guide guide : guides) {
+            if (guide instanceof GrailsVersionedGuide) {
+                for (Integer v : ((GrailsVersionedGuide) guide).grailsMayorVersionTags.keySet()) {
+                    versions.add(v.toString())
+                }
+            } else if (guide.versionNumber) {
+                versions.add(guide.versionNumber)
+            }
+        }
+        List<String> list = new ArrayList<String>(versions)
+        list.sort { String a, String b -> (b as Integer) <=> (a as Integer) }
+        list
+    }
+
+    /** Whether {@code guide} is published for the given Grails major version. */
+    static boolean guideHasVersion(Guide guide, String version) {
+        if (guide instanceof GrailsVersionedGuide) {
+            for (Integer v : ((GrailsVersionedGuide) guide).grailsMayorVersionTags.keySet()) {
+                if (v.toString() == version) {
+                    return true
+                }
+            }
+            return false
+        }
+        guide.versionNumber == version
     }
 }

--- a/buildSrc/src/main/groovy/website/model/guides/GuidesPage.groovy
+++ b/buildSrc/src/main/groovy/website/model/guides/GuidesPage.groovy
@@ -161,7 +161,11 @@ class GuidesPage {
                         mkp.yieldUnescaped(rightColumn(tag, category, version, guides))
                     }
                     div(class: 'column') {
-                        mkp.yieldUnescaped(leftColumn(tag, category, tags, GuidesPage.availableVersions(guides), version))
+                        // leftColumn only renders the clouds (and thus uses the
+                        // version list) on the index and version pages; skip the
+                        // scan/sort of availableVersions for tag/category pages.
+                        def versions = (tag || category) ? [] : GuidesPage.availableVersions(guides)
+                        mkp.yieldUnescaped(leftColumn(tag, category, tags, versions, version))
                         if (tag) {
                             mkp.yieldUnescaped(guideGroupByTag(tag, guides))
                         } else if (category) {


### PR DESCRIPTION
## What

Adds a **"Guides by Grails Version"** filter to the guides listing page, mirroring the existing tag-cloud mechanism.

- A version cloud in the guides index sidebar (above the tag cloud) lists each Grails major version that has guides (8, 6, 5, 4, 3), each linking to a statically generated `/guides/versions/<N>.html` page.
- Each version page lists **every** guide published for that version, newest first, using the existing "Latest Guides" visual treatment (title, date, category, "Read More"). The "Read More" link targets that guide's matching version variant.
- The version page keeps the version + tag clouds in the right column so readers can pivot to another version or a tag.
- The version cloud collapses during search, like the tag cloud.

The version data already existed in the guide model (`SingleGuide.versionNumber` / `GrailsVersionedGuide.grailsMayorVersionTags`); this change just surfaces it as a browse axis. No `conf/guides.yml` schema changes.

## Commits

1. **Make GuidesTask compatible with the configuration cache** - `renderGuides()` resolved `templates/partials` through `project.rootProject` at execution time, which is unsupported with the configuration cache (enabled in `gradle.properties`) and made `genGuides` fail when the cache was active. Now wired as an `@InputDirectory` at configuration time, mirroring `RenderSiteTask`. Pre-existing issue, fixed here so the new version-page generation builds cleanly with the cache.
2. **Add Grails version filter to the guides listing page** - the feature described above.

## Testing

- `./gradlew genGuides` and `./gradlew buildGuides` succeed with the configuration cache **enabled** (entry stored, then reused on a second run).
- Generated `/guides/versions/{3,4,5,6,8}.html`; counts match the corpus (e.g. v8 lists all 10 v8 guides; v5 lists its single guide).
- Verified locally in a browser: the version cloud renders above the tag cloud on the index; version pages show the full guide list on the left with the clouds on the right; search still filters and the version cloud hides during search; the main index page is unchanged.

## Files

- `buildSrc/src/main/groovy/website/model/guides/GuidesPage.groovy` - version cloud, version-page rendering, `availableVersions()` / `guideHasVersion()` helpers.
- `buildSrc/src/main/groovy/website/gradle/tasks/GuidesTask.groovy` - generate `/guides/versions/<N>.html`; configuration-cache fix.
- `assets/javascripts/search.js` - hide the version cloud during search.
- `assets/stylesheets/screen.css` - version-cloud pill styling.
