### PR TITLE
Fix Open Graph URL for generated guides pages

### DIFF
--- a/buildSrc/src/main/groovy/website/gradle/tasks/GuidesTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/GuidesTask.groovy
@@ -205,7 +205,7 @@ abstract class GuidesTask extends GrailsWebsiteTask {
         def guides = GuidesFetcher.fetchGuides(guidesYml)
         def tags = TagUtils.populateTags(guides)
         new File(pages, PAGE_NAME_GUIDES).setText(
-                "title: Guides | Grails Framework\nbody: guides\nJAVASCRIPT: $url/javascripts/search.js\n---\n" +
+                "title: Guides | Grails Framework\nbody: guides\nogurl: $url/guides/index.html\nJAVASCRIPT: $url/javascripts/search.js\n---\n" +
                         GuidesPage.mainContent(guides, tags),
                 'UTF-8'
 
@@ -215,7 +215,7 @@ abstract class GuidesTask extends GrailsWebsiteTask {
         for (def tag : tags) {
             def slug = "${tag.slug.toLowerCase()}.html"
             new File(tagsDir, slug).setText(
-                    "---\ntitle: Guides with tag: $tag.title | Grails Framework\nbody: guides\n---\n" +
+                    "---\ntitle: Guides with tag: $tag.title | Grails Framework\nbody: guides\nogurl: $url/guides/tags/$slug\n---\n" +
                             GuidesPage.mainContent(guides, tags, null, tag),
                     'UTF-8'
 
@@ -225,7 +225,7 @@ abstract class GuidesTask extends GrailsWebsiteTask {
         for (def category : GuidesPage.categories.values()) {
             def slug = "${category.slug.toLowerCase()}.html"
             new File(categoriesDir, slug).setText(
-                    "---\ntitle: Guides at category $category.name | Grails Framework\nbody: guides\n---\n" +
+                    "---\ntitle: Guides at category $category.name | Grails Framework\nbody: guides\nogurl: $url/guides/categories/$slug\n---\n" +
                             GuidesPage.mainContent(guides, tags, category, null),
                     'UTF-8'
             )
@@ -234,7 +234,7 @@ abstract class GuidesTask extends GrailsWebsiteTask {
         for (def version : GuidesPage.availableVersions(guides)) {
             def slug = "${version}.html"
             new File(versionsDir, slug).setText(
-                    "---\ntitle: Guides for Grails $version | Grails Framework\nbody: guides\n---\n" +
+                    "---\ntitle: Guides for Grails $version | Grails Framework\nbody: guides\nogurl: $url/guides/versions/$slug\n---\n" +
                             GuidesPage.mainContent(guides, tags, null, null, version),
                     'UTF-8'
             )

--- a/buildSrc/src/main/groovy/website/gradle/tasks/RenderSiteTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/RenderSiteTask.groovy
@@ -233,9 +233,17 @@ abstract class RenderSiteTask extends GrailsWebsiteTask {
             @Nullable File partialsRoot = null
     ) {
         for (def page : listOfPages) {
-            def resolvedMetadata = processMetadata(
-                    siteMeta + page.metadata + [ogurl: siteMeta['url'] + page.path]
-            )
+            // Default the Open Graph URL to <site><page path>, but let a page
+            // override it via its own `ogurl` metadata. Pages parsed from disk
+            // carry a root-relative path (e.g. "/faq.html"), so the default is
+            // correct for them; generated guide pages (index, tags, categories,
+            // versions) carry only a bare leaf filename (e.g. "8.html"), so they
+            // set `ogurl` explicitly to the right /guides/... URL.
+            def pageMetadata = siteMeta + page.metadata
+            if (!pageMetadata.containsKey('ogurl')) {
+                pageMetadata = pageMetadata + [ogurl: siteMeta['url'] + page.path]
+            }
+            def resolvedMetadata = processMetadata(pageMetadata)
             def html = renderHtmlWithTemplateContent(
                     page.content,
                     resolvedMetadata,


### PR DESCRIPTION
## What

Fixes a pre-existing bug in the Open Graph URL (`og:url`) of the **generated guides pages** (the guides index and the per-tag, per-category, and - since #515 - per-version pages).

`RenderSiteTask.renderPages` computed `ogurl = siteMeta['url'] + page.path` and merged it **last**, overriding any page-provided value. Those generated `Page` objects carry only a bare leaf filename as their path (e.g. `8.html`), so the tag rendered as:

```
<meta property='og:url' content='https://grails.apache.org8.html'/>
```

instead of the real URL. Disk-parsed main-site pages were unaffected because their path is already root-relative (e.g. `/faq.html`).

## Fix

- `RenderSiteTask.renderPages` now applies the computed default `ogurl` **only when the page metadata does not already provide one**, so a page can set its own.
- `GuidesTask` sets the correct absolute `ogurl` in the front-matter of each generated page.

## Before / after

| Page | Before | After |
|------|--------|-------|
| `/guides/index.html` | `https://grails.apache.orgindex.html` | `https://grails.apache.org/guides/index.html` |
| `/guides/versions/8.html` | `https://grails.apache.org8.html` | `https://grails.apache.org/guides/versions/8.html` |
| `/guides/tags/htmx.html` | `https://grails.apache.orghtmx.html` | `https://grails.apache.org/guides/tags/htmx.html` |
| `/guides/categories/gorm.html` | `https://grails.apache.orggorm.html` | `https://grails.apache.org/guides/categories/gorm.html` |

## Testing

- `./gradlew genGuides` - all four generated `og:url` values now resolve correctly (verified in the built HTML).
- `./gradlew build` - main-site pages are unchanged (`https://grails.apache.org/community.html`, `/faq.html`, `/index.html`), confirming the shared `renderPages` change is behavior-preserving for disk-parsed pages (none of which set `ogurl`).

## Notes

This was flagged during the review of #515 as a pre-existing issue that the new version pages inherited; fixing it here in a focused, separate PR.
