### PR TITLE
Fix blank guide root page and consolidate duplicate guide pages onto one canonical URL

### DIFF
--- a/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
@@ -82,6 +82,8 @@ class RenderGuidesPlugin {
     static final String AGGREGATE_TASK = 'buildAllGuides'
     static final String GUIDES_YML_PATH = 'conf/guides.yml'
     static final String GUIDE_TEMPLATE_PATH = 'guides/resources'
+    /** Public base URL for published guides; used to build absolute canonical links. */
+    static final String SITE_GUIDES_BASE = 'https://grails.apache.org/guides'
 
     static void apply(Project project) {
         File guidesYml = project.rootProject.layout.projectDirectory
@@ -211,21 +213,40 @@ class RenderGuidesPlugin {
                     // dist tree so `<img src="../img/foo.png">` resolves.
                     task.doLast {
                         File targetRoot = task.targetDir.get().asFile
-                        File singleHtml = new File(targetRoot, 'guide/single.html')
-                        if (singleHtml.isFile()) {
-                            File indexHtml = new File(targetRoot, 'guide/index.html')
-                            indexHtml.bytes = singleHtml.bytes
-                        }
-                        // DocPublisher also emits a per-version top-level
-                        // index.html with an empty body (legacy frameset-era
-                        // stub). Nothing links to it - the canonical entry is
-                        // guide/index.html - but it is reachable via old
-                        // bookmarks and renders as a blank page. Replace it
-                        // with a meta-refresh redirect to the single-page guide.
                         File guideIndex = new File(targetRoot, 'guide/index.html')
+                        File singleHtml = new File(targetRoot, 'guide/single.html')
+                        // DocPublisher writes the full single-page guide to
+                        // single.html and a separate TOC-only stub to
+                        // guide/index.html. Promote the single page to the
+                        // canonical guide/index.html URL.
+                        if (singleHtml.isFile()) {
+                            guideIndex.bytes = singleHtml.bytes
+                        }
+                        // De-duplicate every other HTML the renderer emits for
+                        // this guide-version onto that one canonical URL so they
+                        // do not compete with it in search results, while still
+                        // resolving for any old bookmark:
+                        //   - the per-version top-level index.html (empty
+                        //     frameset-era stub) -> guide/index.html
+                        //   - guide/single.html (byte-identical duplicate of
+                        //     guide/index.html) -> index.html (its sibling)
+                        //   - guide/pages/*.html (granular sub-section pages the
+                        //     vendored renderer itself flags as unnecessary, and
+                        //     which nothing links to) -> ../index.html
                         if (guideIndex.isFile()) {
-                            RenderGuidesPlugin.writeGuideIndexRedirect(
-                                    new File(targetRoot, 'index.html'))
+                            RenderGuidesPlugin.writeRedirectStub(
+                                    new File(targetRoot, 'index.html'), 'guide/index.html')
+                            if (singleHtml.isFile()) {
+                                RenderGuidesPlugin.writeRedirectStub(singleHtml, 'index.html')
+                            }
+                            File pagesDir = new File(targetRoot, 'guide/pages')
+                            if (pagesDir.isDirectory()) {
+                                pagesDir.eachFile { File p ->
+                                    if (p.isFile() && p.name.endsWith('.html')) {
+                                        RenderGuidesPlugin.writeRedirectStub(p, '../index.html')
+                                    }
+                                }
+                            }
                         }
                         File stagedImgDir = project.layout.buildDirectory
                                 .dir(stagedRelPath + '/img').get().asFile
@@ -631,21 +652,31 @@ class RenderGuidesPlugin {
         // Legacy guide layout templates expect this name directly.
         attrs['grailsVersion'] = versionKey
 
+        // Absolute canonical URL for every page of this guide-version. All
+        // rendered pages (the single-page guide, the per-chapter pages, and
+        // the redirect stubs) point their <link rel="canonical"> here so the
+        // search engines treat /guide/index.html as the one indexable URL and
+        // the per-chapter / single.html duplicates do not compete with it.
+        if (guide.name) {
+            attrs['canonicalUrl'] =
+                    "${SITE_GUIDES_BASE}/${guide.name}/${versionKey}/guide/index.html".toString()
+        }
+
         attrs
     }
 
     /**
-     * Writes a meta-refresh redirect at the per-version guide root
-     * ({@code /<guide>/<version>/index.html}) pointing at the canonical
-     * single-page rendering ({@code guide/index.html}). The vendored
-     * DocPublisher emits an empty-bodied stub there (legacy frameset-era
-     * behaviour); this replaces it so old bookmarks land on real content
-     * instead of a blank page. The target is relative so it resolves both
-     * locally (file://) and on the published site. No inline script is used,
-     * keeping the page within the guides CSP allowlist.
+     * Overwrites {@code target} with a meta-refresh redirect to {@code dest},
+     * a path relative to {@code target} so it resolves both locally
+     * ({@code file://}) and on the published site. Used to collapse the
+     * duplicate / empty guide pages the vendored DocPublisher emits (the
+     * per-version root {@code index.html}, {@code guide/single.html}, and
+     * {@code guide/pages/*.html}) onto the canonical {@code guide/index.html}
+     * without ever leaving a dangling URL. The {@code canonical} link and
+     * {@code noindex} keep the redirect out of search results, and no inline
+     * script is used so the page stays within the guides CSP allowlist.
      */
-    static void writeGuideIndexRedirect(File target) {
-        String dest = 'guide/index.html'
+    static void writeRedirectStub(File target, String dest) {
         target.parentFile.mkdirs()
         target.setText("""<!DOCTYPE html>
 <html lang="en">

--- a/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
@@ -216,6 +216,17 @@ class RenderGuidesPlugin {
                             File indexHtml = new File(targetRoot, 'guide/index.html')
                             indexHtml.bytes = singleHtml.bytes
                         }
+                        // DocPublisher also emits a per-version top-level
+                        // index.html with an empty body (legacy frameset-era
+                        // stub). Nothing links to it - the canonical entry is
+                        // guide/index.html - but it is reachable via old
+                        // bookmarks and renders as a blank page. Replace it
+                        // with a meta-refresh redirect to the single-page guide.
+                        File guideIndex = new File(targetRoot, 'guide/index.html')
+                        if (guideIndex.isFile()) {
+                            RenderGuidesPlugin.writeGuideIndexRedirect(
+                                    new File(targetRoot, 'index.html'))
+                        }
                         File stagedImgDir = project.layout.buildDirectory
                                 .dir(stagedRelPath + '/img').get().asFile
                         if (stagedImgDir.isDirectory()) {
@@ -621,6 +632,35 @@ class RenderGuidesPlugin {
         attrs['grailsVersion'] = versionKey
 
         attrs
+    }
+
+    /**
+     * Writes a meta-refresh redirect at the per-version guide root
+     * ({@code /<guide>/<version>/index.html}) pointing at the canonical
+     * single-page rendering ({@code guide/index.html}). The vendored
+     * DocPublisher emits an empty-bodied stub there (legacy frameset-era
+     * behaviour); this replaces it so old bookmarks land on real content
+     * instead of a blank page. The target is relative so it resolves both
+     * locally (file://) and on the published site. No inline script is used,
+     * keeping the page within the guides CSP allowlist.
+     */
+    static void writeGuideIndexRedirect(File target) {
+        String dest = 'guide/index.html'
+        target.parentFile.mkdirs()
+        target.setText("""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Redirecting to ${dest}</title>
+<link rel="canonical" href="${dest}">
+<meta http-equiv="refresh" content="0; url=${dest}">
+<meta name="robots" content="noindex">
+</head>
+<body>
+<p>This page has moved. <a href="${dest}">View the guide</a>.</p>
+</body>
+</html>
+""", 'UTF-8')
     }
 
     @CompileDynamic

--- a/buildSrc/src/main/groovy/website/gradle/tasks/SitemapTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/SitemapTask.groovy
@@ -22,6 +22,9 @@ import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import groovy.xml.MarkupBuilder
 
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
@@ -71,20 +74,66 @@ abstract class SitemapTask extends GrailsWebsiteTask {
         }
     }
 
+    // A page that redirects elsewhere (meta-refresh) or opts out of indexing
+    // (robots noindex) must never appear in the sitemap.
+    private static final Pattern REFRESH = Pattern.compile(
+            '(?is)<meta[^>]+http-equiv\\s*=\\s*["\']refresh["\']')
+    private static final Pattern NOINDEX = Pattern.compile(
+            '(?is)<meta[^>]+name\\s*=\\s*["\']robots["\'][^>]*noindex')
+    // <link rel="canonical" href="..."> - if a page declares a canonical that
+    // is not itself, it is a duplicate and the canonical owns the sitemap slot.
+    private static final Pattern CANONICAL = Pattern.compile(
+            '(?is)<link[^>]+rel\\s*=\\s*["\']canonical["\'][^>]*href\\s*=\\s*["\']([^"\']+)["\']')
+
     @TaskAction
     void renderSitemap() {
-        def websiteUrl = url.get()
+        String websiteUrl = url.get()
         List<String> urls = []
-        def inputDirectory = inputDir.get().asFile
-        inputDirectory.eachFileRecurse(FILES) {
-            if (it.name.endsWith('.html')) {
-                urls.add(websiteUrl + it.absolutePath.replace(inputDirectory.absolutePath, ''))
+        File inputDirectory = inputDir.get().asFile
+        String rootPath = inputDirectory.absolutePath
+        inputDirectory.eachFileRecurse(FILES) { File f ->
+            if (!f.name.endsWith('.html')) {
+                return
+            }
+            String relPath = f.absolutePath.substring(rootPath.length()).replace('\\', '/')
+            String ownUrl = websiteUrl + relPath
+            if (isIndexable(f, ownUrl)) {
+                urls.add(ownUrl)
             }
         }
         outputFile.get().asFile.with {
             parentFile.mkdirs()
             text = sitemapContent(urls.sort())
         }
+    }
+
+    /**
+     * A page belongs in the sitemap only if it is not a redirect / noindex stub
+     * and either declares no canonical or names itself as the canonical. This
+     * drops the per-guide duplicates (the per-version root {@code index.html},
+     * {@code guide/single.html}, {@code guide/pages/*.html} redirects and the
+     * per-chapter pages that point their canonical at {@code guide/index.html})
+     * while leaving every ordinary site page untouched.
+     */
+    private static boolean isIndexable(File f, String ownUrl) {
+        String text = f.getText('UTF-8')
+        if (REFRESH.matcher(text).find() || NOINDEX.matcher(text).find()) {
+            return false
+        }
+        Matcher m = CANONICAL.matcher(text)
+        if (m.find()) {
+            return pathOnly(m.group(1)) == pathOnly(ownUrl)
+        }
+        return true
+    }
+
+    /** Strips scheme + host so canonical/own URLs compare by path alone. */
+    private static String pathOnly(String u) {
+        Matcher m = Pattern.compile('^[a-zA-Z][a-zA-Z0-9+.-]*://[^/]+(/.*)?$').matcher(u)
+        if (m.matches()) {
+            return m.group(1) ?: '/'
+        }
+        return u
     }
 
     @CompileDynamic

--- a/guides/resources/style/guideItem.html
+++ b/guides/resources/style/guideItem.html
@@ -4,6 +4,7 @@
 <head>
     <title>${sectionNumber} ${title.encodeAsHtml()}</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <link rel="canonical" href="${canonicalUrl}"/>
     <link rel="stylesheet" href="${resourcesPath}/css/main.css" type="text/css" media="screen, print" title="Style" charset="utf-8"/>
     <link rel="stylesheet" href="${resourcesPath}/css/guide.css" type="text/css" media="screen, print" title="Style" charset="utf-8" />            
     <link rel="stylesheet" href="${resourcesPath}/css/pdf.css" type="text/css" media="print" title="PDF" charset="utf-8"/>

--- a/guides/resources/style/layout.html
+++ b/guides/resources/style/layout.html
@@ -3,6 +3,7 @@
 <head>
     <title>${title.encodeAsHtml()} | Grails Guides | Apache Grails</title>
     <meta name='description' content='${title.encodeAsHtml()}. ${subtitle?.encodeAsHtml()}'/>
+    <link rel='canonical' href='${canonicalUrl}'/>
     ${siteHead}
     <link rel='stylesheet' href='${resourcesPath}/css/guide.css'/>
     <script src='${resourcesPath}/js/clipboard.min.js'></script>


### PR DESCRIPTION
## Problem

Two related issues with how guides are published:

1. **Blank page.** Opening an older guide at its per-version root, e.g. `https://grails.apache.org/guides/grails-database-migration/6/index.html`, rendered a blank page - only the header and TOC sidebar, no body.
2. **Duplicate content (SEO).** Each guide-version exposed ~17 indexable HTML pages presenting the same material with **no canonical signal**: the full single-page guide (`guide/index.html`), a byte-identical `guide/single.html`, the per-chapter `guide/*.html` pages, the granular `guide/pages/*.html` sub-section pages, and the empty per-version root `index.html`. `SitemapTask` submitted every one of them, so search engines saw many competing URLs per guide.

## Root cause

The vendored grails-doc renderer (`DocPublisher`, via `PublishGuideTask`, wired by `RenderGuidesPlugin`) emits all of the above per guide-version. The canonical entry used everywhere on the site is `/<guide>/<version>/guide/index.html`, but nothing collapsed the other pages onto it, and none of them carried a `<link rel="canonical">`.

## Fix

Consolidate everything onto `guide/index.html`:

- **Canonical tags.** A single absolute `canonicalUrl` is derived in `RenderGuidesPlugin` and emitted as `<link rel="canonical">` on every guide page via the `layout.html` and `guideItem.html` templates. `guide/index.html` is self-referential; the per-chapter pages point at it.
- **Redirects, not deletions.** The duplicate/empty pages become relative meta-refresh redirects (noindex, no inline script -> CSP-safe) so they de-duplicate **without ever leaving a dangling URL**:
  - per-version root `index.html` -> `guide/index.html`
  - `guide/single.html` -> `index.html`
  - every `guide/pages/*.html` -> `../index.html` (verified 0 inbound links)

  The redirect helper is generalized to `writeRedirectStub(target, dest)`.
- **Sitemap.** `SitemapTask` now lists only genuinely indexable canonical URLs - it skips any page that is a redirect/noindex stub or whose canonical names a different URL. Result: exactly **one** URL per guide-version (`guide/index.html`).

Runs for every guide-version, so older guides and current Grails 8 guides are both covered.

## Verification

Rebuilt and loaded in a real browser (served over HTTP):

- **Old** `grails-database-migration` v6 and **new** `grails-fields-custom-widgets-and-wrappers` v8:
  - `guide/index.html` - self-canonical, full body renders, **0 console errors**
  - root `index.html`, `guide/single.html`, `guide/pages/*.html` - all redirect to `guide/index.html` in the browser
  - `sitemap.xml` lists exactly **1** URL per guide-version (was ~17)

`buildSrc` compiles and both `renderGuide_*` and `genSitemap` run cleanly. The only failing `buildSrc` tests (`RecordCompanionReleaseTaskSpec`, `ValidateGuidesTaskSpec`) fail identically on `master` without this change and are unrelated.
