### PR TITLE
Object Computing link updated

### DIFF
--- a/pages/support.html
+++ b/pages/support.html
@@ -38,7 +38,7 @@ CSS: /stylesheets/support.css
             </li>
             <li>North America
                 <ul>
-                    <li><a href="https://objectcomputing.com/platforms/grails" rel="nofollow noopener noreferrer"
+                    <li><a href="https://objectcomputing.com/" rel="nofollow noopener noreferrer"
                            target="_blank">Object Computing, Inc.</a></li>
                     <li><a href="https://www.triumphinteractive.com/" rel="nofollow noopener noreferrer" target="_blank">Triumph
                         Interactive, Inc.</a></li>


### PR DESCRIPTION
OCI no longer have a Grails specific sub-page (it returns 404) so the link is changed to their frontpage.